### PR TITLE
Added option to summon the bot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let start = SystemTime::now();
         let comments = reddit_client
-            .get_comments(subreddits, API_COMMENT_COUNT, &already_replied_or_rejected)
+            .get_comments(
+                subreddits,
+                API_COMMENT_COUNT,
+                &mut already_replied_or_rejected,
+            )
             .await
             .unwrap_or_default();
         let end = SystemTime::now();
@@ -88,7 +92,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             if status.number_too_big_to_calculate {
                 println!(" -> number too big to calculate");
-                already_replied_or_rejected.push(comment_id.clone());
                 continue;
             }
 
@@ -104,7 +107,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let reply: String = comment.get_reply();
                 match reddit_client.reply_to_comment(comment, &reply).await {
                     Ok(_) => {
-                        already_replied_or_rejected.push(comment_id.clone());
                         influxdb::log_comment_reply(
                             influx_client,
                             &comment_id,

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -129,6 +129,8 @@ impl RedditClient {
                         .expect("Failed to extract comments");
                 res.extend(mentions);
                 res.extend(parents);
+                res.sort();
+                res.dedup();
                 Ok(res)
             }
             Err(_) => Err(()),

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -462,7 +462,7 @@ mod tests {
                     "HTTP/1.1 200 OK\n\n{\"data\":{\"children\":[{\"kind\": \"t1\",\"data\":{\"body\":\"u/factorion-bot\",\"parent_id\":\"t1_m38msum\",\"context\":\"/r/some_sub/8msu32a/some_post/m38msun/?context=3\"}}]}}"
                 ),(
                     "GET /r/some_sub/8msu32a/some_post/m38msum/ HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
-                    "HTTP/1.1 200 OK\n\n[{}]"
+                    "HTTP/1.1 200 OK\n\n[{\"data\":{\"id\":\"m38msum\", \"body\":\"That's 57!\"}}]"
                 )]).await
             },
             client.get_comments("test_subreddit", 100, &[])

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -230,7 +230,7 @@ impl RedditClient {
             ("grant_type", "password"),
             ("username", username.as_str()),
             ("password", password.as_str()),
-            ("scope", "read submit"),
+            ("scope", "read submit privatemessages"),
         ];
 
         let response = Client::new()

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -410,7 +410,7 @@ mod tests {
         }
         let (status, client) = join!(
             dummy_server(&[(
-                "POST / HTTP/1.1\r\nuser-agent: factorion-bot:v1.4.0 (by /u/tolik518)\r\ncontent-type: application/x-www-form-urlencoded\r\nauthorization: Basic YW4gaWQ6YSBzZWNyZXQ=\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\ncontent-length: 77\r\n\r\ngrant_type=password&username=a+username&password=a+password&scope=read+submit",
+                "POST / HTTP/1.1\r\nuser-agent: factorion-bot:v1.4.0 (by /u/tolik518)\r\ncontent-type: application/x-www-form-urlencoded\r\nauthorization: Basic YW4gaWQ6YSBzZWNyZXQ=\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\ncontent-length: 93\r\n\r\ngrant_type=password&username=a+username&password=a+password&scope=read+submit+privatemessages",
                 "HTTP/1.1 200 OK\n\n{\"access_token\": \"eyJhbGciOiJSUzI1NiIsImtpZCI6IlNIQTI1NjpzS3dsMnlsV0VtMjVmcXhwTU40cWY4MXE2OWFFdWFyMnpLMUdhVGxjdWNZIiwidHlwIjoiSldUIn0.eyJzdWIiOiJ1c2dyIiwiZXhwIjoxNzM1MTQ0NjI0LjQ2OTAyLCJpYXQiOjE3MzUwNTgyMjQuNDY5MDIsImp0aSI6IlpDM0Y2YzVXUGh1a09zVDRCcExaa0lmam1USjBSZyIsImNpZCI6IklJbTJha1RaRDFHWXd5Y1lXTlBKWVEiLCJsaWQiOiJ0dl96bnJ5dTJvM1QiLCJhaWQiOiJ0Ml96bnJ5dT1vMjQiLCJsY2EiOjE3MTQ4MjU0NzQ3MDIsInNjcCI6ImVKeUtWaXBLVFV4UjBsRXFMazNLelN4UmlnVUVBQUpfX3pGR0JaMCIsImZsbyI6OX0.o3X9CJAUED1iYsFs8h_02NvaDMmPVSIaZgz3aPjEGm3zF5cG2-G2tU7yIJUtqGICxT0W3-PAso0jwrrx3ScSGucvhEiUVXOiGcCZSzPfLnwuGxtRa_lNEkrsLAVlhN8iXBRGds8YkJ0MFWn4JRwhi8beV3EsFkEzN6IsESuA33WUQQgGs0Ij5oH0If3EMLoBoDVQvWdp2Yno0SV9xdODP6pMJSKZD5HVgWGzprFlN2VWmgb4HXs3mrxbE5bcuO_slah0xcqnhcXmlYCdRCSqeEUtlW8pS4Wtzzs7BL5E70A5LHmHJfGJWCh-loInwarxeq_tVPoxikzqBrTIEsLmPA\"}"
             )]),
             RedditClient::new()

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -10,7 +10,7 @@ use rug::{Float, Integer};
 use std::fmt::Write;
 use std::sync::LazyLock;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq)]
 pub(crate) struct RedditComment {
     pub(crate) id: String,
     pub(crate) calculation_list: Vec<Calculation>,
@@ -20,7 +20,7 @@ pub(crate) struct RedditComment {
     pub(crate) commands: Commands,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub(crate) struct Status {
     pub(crate) already_replied_or_rejected: bool,
     pub(crate) not_replied: bool,
@@ -81,7 +81,7 @@ impl Status {
     };
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
 pub(crate) struct Commands {
     shorten: bool,
     include_steps: bool,


### PR DESCRIPTION
I implemented summoning the bot through mentions. The bot now also looks through its mentions and, if a mention is purely that (just "u/factorion-bot"), also the comment that the mention is replying to. 

I checked the data structure and tested as much as I could (unit-test and curl with my account bearer token), but can't test if it truly works with the api. 

One negative aspect of this is, that it uses at least one more request per loop. And for every "pure mention" one extra.

Resolves #32 