### PR TITLE
Fix steps command for towers

### DIFF
--- a/src/calculation_tasks.rs
+++ b/src/calculation_tasks.rs
@@ -83,14 +83,20 @@ impl FactorialTask {
                                     let base_levels = levels;
                                     let mut levels = vec![level];
                                     levels.extend(base_levels);
-                                    return vec![Some(Calculation::Factorial(Factorial {
+                                    let factorial = Some(Calculation::Factorial(Factorial {
                                         value: number.clone(),
                                         levels,
                                         factorial: CalculatedFactorial::ApproximateDigitsTower(
                                             1,
                                             exponent.clone() + math::length(exponent),
                                         ),
-                                    }))];
+                                    }));
+                                    if include_steps {
+                                        factorials.push(factorial);
+                                    } else {
+                                        factorials = vec![factorial];
+                                    }
+                                    return factorials;
                                 };
                                 Number::Int(res)
                             }
@@ -98,14 +104,20 @@ impl FactorialTask {
                                 let base_levels = levels;
                                 let mut levels = vec![level];
                                 levels.extend(base_levels);
-                                return vec![Some(Calculation::Factorial(Factorial {
+                                let factorial = Some(Calculation::Factorial(Factorial {
                                     value: number.clone(),
                                     levels,
                                     factorial: CalculatedFactorial::ApproximateDigitsTower(
                                         1,
                                         digits.clone() + math::length(digits),
                                     ),
-                                }))];
+                                }));
+                                if include_steps {
+                                    factorials.push(factorial);
+                                } else {
+                                    factorials = vec![factorial];
+                                }
+                                return factorials;
                             }
                             CalculatedFactorial::ApproximateDigitsTower(depth, exponent) => {
                                 let base_levels = levels;
@@ -122,7 +134,7 @@ impl FactorialTask {
                                     }
                                     extra = extra.log10();
                                 }
-                                return vec![Some(Calculation::Factorial(Factorial {
+                                let factorial = Some(Calculation::Factorial(Factorial {
                                     value: number.clone(),
                                     levels,
                                     factorial: CalculatedFactorial::ApproximateDigitsTower(
@@ -133,7 +145,13 @@ impl FactorialTask {
                                                 .map(|(n, _)| n)
                                                 .unwrap_or(0.into()),
                                     ),
-                                }))];
+                                }));
+                                if include_steps {
+                                    factorials.push(factorial);
+                                } else {
+                                    factorials = vec![factorial];
+                                }
+                                return factorials;
                             }
                             CalculatedFactorial::Gamma(gamma) => Number::Float(gamma.clone()),
                         };

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -325,11 +325,7 @@ impl RedditComment {
             );
             }
         } else if self.calculation_list.iter().any(Calculation::is_rounded) {
-            if multiple {
-                let _ = note.write_str("I can't calculate that large factorials of decimals. So I had to round it at some point.\n\n");
-            } else {
-                let _ = note.write_str("I can't calculate that large factorials of decimals. So I had to round it at some point.\n\n");
-            }
+            let _ = note.write_str("I can't calculate that large factorials of decimals. So I had to round at some point.\n\n");
         } else if self.calculation_list.iter().any(Calculation::is_too_long) {
             if multiple {
                 let _ = note.write_str("If I post the whole numbers, the comment would get too long, as reddit only allows up to 10k characters. So I had to turn them into scientific notation.\n\n");

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -681,6 +681,18 @@ mod tests {
     }
 
     #[test]
+    fn test_command_steps_tower() {
+        let comment = RedditComment::new(
+            "This comment would like to know all the steps to this factorial chain (((9!)!)!)! \\[all\\] \\[short\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+        );
+        let reply = comment.get_reply();
+        assert_eq!(reply, "Some of these are so large, that I can't even give the number of digits of them, so I have to make a power of ten tower.\n\nThe factorial of 9 is 362880 \n\nThe factorial of The factorial of 9 is roughly 1.609714400410012621103443610733 × 10^1859933 \n\nThe factorial of The factorial of The factorial of 9 has approximately 2.993960567614282167996111938338 × 10^1859939 digits \n\nThe factorial of The factorial of The factorial of The factorial of 9 has on the order of 10^(2.993960567614282167996111938338 × 10^1859939) digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*");
+    }
+
+    #[test]
     fn test_reply_text_shorten() {
         let comment = RedditComment::new(
             "3500! 3501! 3502! 3503! 3504! 3505! 3506! 3507! 3508! 3509! 3510! 3511! 3512! 3513! 3514! 3515! 3516! 3517! 3518! 3519! 3520! 3521! 3522! 3523! 3524! 3525! 3526! 3527! 3528! 3529! 3530! 3531! 3532! 3533! 3534! 3535! 3536! 3537! 3538! 3539! 3540! 3541! 3542! 3543! 3544! 3545! 3546! 3547! 3548! 3549! 3550! 3551! 3552! 3553! 3554! 3555! 3556! 3557! 3558! 3559! 3560! 3561! 3562! 3563! 3564! 3565! 3566! 3567! 3568! 3569! 3570! 3571! 3572! 3573! 3574! 3575! 3576! 3577! 3578! 3579! 3580! 3581! 3582! 3583! 3584! 3585! 3586! 3587! 3588! 3589! 3590! 3591! 3592! 3593! 3594! 3595! 3596! 3597! 3598! 3599! 3600! 3600! 3601! 3602! 3603! 3604! 3605! 3606! 3607! 3608! 3609! 3610! 3611! 3612! 3613! 3614! 3615! 3616! 3617! 3618! 3619! 3620! 3621! 3622! 3623! 3624! 3625! 3626! 3627! 3628! 3629! 3630! 3631! 3632! 3633! 3634! 3636! 3636! 3637! 3638! 3639! 3640! 3641! 3642! 3643! 3644! 3645! 3646! 3647! 3648! 3649! 3650! 3651! 3652! 3653! 3654! 3655! 3656! 3657! 3658! 3659! 3660! 3661! 3662! 3663! 3664! 3665! 3666! 3667! 3668! 3669! 3670! 3671! 3672! 3673! 3674! 3675! 3676! 3677! 3678! 3679! 3680! 3681! 3682! 3683! 3684! 3685! 3686! 3687! 3688! 3689! 3690! 3691! 3692! 3693! 3694! 3695! 3696! 3697! 3698! 3699! 3600!",


### PR DESCRIPTION
I noticed a bug [here](https://www.reddit.com/r/unexpectedfactorial/comments/1j92aa1/comment/mhcsiuw/) and figured out, that it is a problem of digit towers. As they returned early they didn't respect `include_steps`.