### PR TITLE
Fix summon performance

### DIFF
--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -327,7 +327,9 @@ impl RedditClient {
             .cloned()
             .unwrap_or_default();
 
+        already_replied_to_comments.reserve(comments_json.len());
         let mut comments = Vec::new();
+        comments.reserve(comments_json.len());
         let mut parent_paths = Vec::new();
         for comment in comments_json {
             comments.push(Self::extract_comment(&comment, already_replied_to_comments));

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -315,18 +315,18 @@ impl RedditClient {
         response: Response,
         already_replied_to_comments: &mut Vec<String>,
     ) -> Result<(Vec<RedditComment>, Vec<String>), Box<dyn std::error::Error>> {
+        let empty_vec = Vec::new();
         let response_json = response.json::<Value>().await?;
         let comments_json = response_json["data"]["children"]
             .as_array()
-            .cloned()
-            .unwrap_or_default();
+            .unwrap_or(&empty_vec);
 
         already_replied_to_comments.reserve(comments_json.len());
         let mut comments = Vec::new();
         comments.reserve(comments_json.len());
         let mut parent_paths = Vec::new();
         for comment in comments_json {
-            let extracted_comment = Self::extract_comment(&comment, already_replied_to_comments);
+            let extracted_comment = Self::extract_comment(comment, already_replied_to_comments);
             if comment["data"]["body"]
                 .as_str()
                 .map(|s| s.contains("u/factorion-bot"))
@@ -334,7 +334,7 @@ impl RedditClient {
                 && extracted_comment.status.no_factorial
                 && extracted_comment.status.not_replied
             {
-                if let Some(path) = Self::extract_summon_parent_path(&comment) {
+                if let Some(path) = Self::extract_summon_parent_path(comment) {
                     parent_paths.push(path);
                 }
             }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -112,7 +112,7 @@ impl RedditClient {
                         .await
                         .expect("Failed to get comment");
                     let parent = RedditClient::extract_comment(
-                        response
+                        &response
                             .json::<Value>()
                             .await
                             .expect("Response isn't JSON")
@@ -302,7 +302,7 @@ impl RedditClient {
         Ok(())
     }
 
-    fn extract_summon_parent_path(comment: Value) -> Option<String> {
+    fn extract_summon_parent_path(comment: &Value) -> Option<String> {
         if comment["data"]["body"].as_str() == Some("u/factorion-bot")
             && comment["kind"].as_str() == Some("t1")
         {
@@ -330,11 +330,8 @@ impl RedditClient {
         let mut comments = Vec::new();
         let mut parent_paths = Vec::new();
         for comment in comments_json {
-            comments.push(Self::extract_comment(
-                comment.clone(),
-                already_replied_to_comments,
-            ));
-            if let Some(path) = Self::extract_summon_parent_path(comment) {
+            comments.push(Self::extract_comment(&comment, already_replied_to_comments));
+            if let Some(path) = Self::extract_summon_parent_path(&comment) {
                 parent_paths.push(path);
             }
         }
@@ -342,7 +339,7 @@ impl RedditClient {
         Ok((comments, parent_paths))
     }
     fn extract_comment(
-        comment: Value,
+        comment: &Value,
         already_replied_to_comments: &mut Vec<String>,
     ) -> RedditComment {
         let comment_text = comment["data"]["body"].as_str().unwrap_or("");


### PR DESCRIPTION
Some attempts to fix the performance regression. Avoid cloning and other allocations.

Have only been able to check extract comments, which by all logic should be the reason, but only got a 30% improvement for now. (So still over double the expected)

Resolves #99 