### PR TITLE
Fix panic on '.5!' (BOT DOWN URGENT!)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -161,7 +161,7 @@ impl RedditComment {
 
     fn extract_calculation_jobs(text: &str, include_termial: bool) -> Vec<CalculationJob> {
         static FACTORIAL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)(\d*\.?\d+)(!+)(?![<\d]|&lt;|\)?[!?])")
+            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)(\d+\.\d+|\d+)(!+)(?![<\d]|&lt;|\)?[!?])")
                 .expect("Invalid factorial regex")
         });
         static SUBFACTORIAL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -169,11 +169,11 @@ impl RedditComment {
                 .expect("Invalid subfactorial regex")
         });
         static TERMIAL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)(\d*\.?\d+)(\?)(?![<\d]|&lt;|\)?[!?])")
+            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)(\d+\.\d+|\d+)(\?)(?![<\d]|&lt;|\)?[!?])")
                 .expect("Invalid factorial regex")
         });
         static FACTORIAL_PAREN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)\((-*\d*\.?\d+)\)(!+)(?![<\d]|&lt;|\)?[!?])")
+            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)\((-*\d+\.\d+|-*\d+)\)(!+)(?![<\d]|&lt;|\)?[!?])")
                 .expect("Invalid factorial regex")
         });
         static SUBFACTORIAL_PAREN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -181,7 +181,7 @@ impl RedditComment {
                 .expect("Invalid subfactorial regex")
         });
         static TERMIAL_PAREN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)\((-*\d*\.?\d+)\)(\?)(?![<\d]|&lt;|\)?[!?])")
+            Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)\((-*\d+\.\d+|-*\d+)\)(\?)(?![<\d]|&lt;|\)?[!?])")
                 .expect("Invalid factorial regex")
         });
         static FACTORIAL_CHAIN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -776,6 +776,18 @@ mod tests {
         assert_eq!(comment.status, Status::NO_FACTORIAL);
     }
 
+    #[test]
+    fn test_comment_new_decimals_incomplete() {
+        let comment = RedditComment::new(
+            "This is a test comment with decimal number .5!",
+            "123",
+            "test_author",
+            "test_subreddit",
+            false,
+        );
+        assert_eq!(comment.calculation_list, []);
+        assert_eq!(comment.status, Status::NO_FACTORIAL);
+    }
     #[test]
     fn test_comment_new_comma_decimals() {
         let comment = RedditComment::new(


### PR DESCRIPTION
The bot has now been down since 6:30. I checked any panics I may have introduced and found that the merged (decimal and integer) regex allowed '.5!' through, which is then rejected by the Float parser. As already read is then not saved, it chrashes everytime it starts up and gets to that comment, which is until, if it is a normal comment, 100 new comments have been made or, if it is a mention, basically forever.

On that note, I would recommend protecting against such crashes, by catching the unwind of `RedditComment::new`.