### PR TITLE
Merge TERMINAL_SUBREDDITS into SUBREDDITS generically for all commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,10 +60,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
         })
         .collect::<HashMap<_, _>>();
-    let subreddits = commands.keys().fold(String::new(), |mut a, e| {
-        write!(a, "{e}").unwrap();
-        a
-    });
+    let subreddits = commands
+        .keys()
+        .map(ToString::to_string)
+        .reduce(|a, e| format!("{a}+{e}"))
+        .unwrap_or_default();
     SUBREDDIT_COMMANDS.set(commands).unwrap();
     SUBREDDITS.set(subreddits.leak()).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 sub,
                 commands
                     .split(',')
-                    .map(|command| match command {
+                    .map(|command| match command.trim() {
                         "shorten" => Commands::SHORTEN,
                         "termial" => Commands::TERMIAL,
                         "steps" => Commands::STEPS,
                         "no_note" => Commands::NO_NOTE,
+                        "" => Commands::NONE,
                         s => Err(s).expect("Unknown command in subreddit {sub}"),
                     })
                     .fold(Commands::NONE, |a, e| a | e),

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -1,9 +1,10 @@
 #![allow(deprecated)] // base64::encode is deprecated
 
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use crate::reddit_comment::{RedditComment, Status};
-use crate::{COMMENT_COUNT, SUBREDDITS, TERMIAL_SUBREDDITS};
+use crate::reddit_comment::{Commands, RedditComment, Status};
+use crate::{COMMENT_COUNT, SUBREDDITS, SUBREDDIT_COMMANDS};
 use anyhow::{anyhow, Error};
 use base64::engine::general_purpose::STANDARD_NO_PAD;
 use base64::Engine;
@@ -137,7 +138,7 @@ impl RedditClient {
                         mentions_response,
                         already_replied_to_comments,
                         true,
-                        TERMIAL_SUBREDDITS.get().copied().unwrap_or_default(),
+                        SUBREDDIT_COMMANDS.get().unwrap(),
                     )
                     .await
                     .expect("Failed to extract comments");
@@ -149,7 +150,7 @@ impl RedditClient {
                     subs_response,
                     already_replied_to_comments,
                     false,
-                    TERMIAL_SUBREDDITS.get().copied().unwrap_or_default(),
+                    SUBREDDIT_COMMANDS.get().unwrap(),
                 )
                 .await
                 .expect("Failed to extract comments");
@@ -170,7 +171,7 @@ impl RedditClient {
                             response,
                             already_replied_to_comments,
                             true,
-                            TERMIAL_SUBREDDITS.get().copied().unwrap_or_default(),
+                            SUBREDDIT_COMMANDS.get().unwrap(),
                         )
                         .await
                         .expect("Failed to extract comments");
@@ -364,7 +365,7 @@ impl RedditClient {
         response: Response,
         already_replied_to_comments: &mut Vec<String>,
         is_mention: bool,
-        termial_subreddits: &str,
+        termial_subreddits: &HashMap<&str, Commands>,
     ) -> Result<(Vec<RedditComment>, Vec<String>), Box<dyn std::error::Error>> {
         let empty_vec = Vec::new();
         let response_json = response.json::<Value>().await?;
@@ -401,7 +402,7 @@ impl RedditClient {
         comment: &Value,
         already_replied_to_comments: &mut Vec<String>,
         do_termial: bool,
-        termial_subreddits: &str,
+        commands: &HashMap<&str, Commands>,
     ) -> Option<RedditComment> {
         let comment_text = comment["data"]["body"].as_str().unwrap_or("");
         let author = comment["data"]["author"].as_str().unwrap_or("");
@@ -420,7 +421,11 @@ impl RedditClient {
                     comment_id,
                     author,
                     subreddit,
-                    do_termial || termial_subreddits.split('+').any(|sub| sub == subreddit),
+                    if do_termial {
+                        Commands::TERMIAL
+                    } else {
+                        Commands::NONE
+                    } | commands.get(subreddit).copied().unwrap_or(Commands::NONE),
                 )
             }) else {
                 println!("Failed to construct comment!");
@@ -538,6 +543,7 @@ mod tests {
             },
         };
         let _ = SUBREDDITS.set("test_subreddit");
+        let _ = SUBREDDIT_COMMANDS.set([("test_subreddit", Commands::TERMIAL)].into());
         let _ = COMMENT_COUNT.set(100);
         let mut already_replied = vec![];
         let (status, comments) = join!(
@@ -604,9 +610,10 @@ mod tests {
                }
            }"#).unwrap());
         let mut already_replied = vec![];
-        let comments = RedditClient::extract_comments(response, &mut already_replied, true, "")
-            .await
-            .unwrap();
+        let comments =
+            RedditClient::extract_comments(response, &mut already_replied, true, &HashMap::new())
+                .await
+                .unwrap();
         assert_eq!(comments.0.len(), 3);
         assert_eq!(comments.1, ["t1_m38msum"]);
         println!("{:#?}", comments);

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -97,6 +97,17 @@ impl std::ops::BitOr for Commands {
         }
     }
 }
+impl std::ops::BitXor for Commands {
+    type Output = Self;
+    fn bitxor(self, rhs: Self) -> Self::Output {
+        Self {
+            shorten: self.shorten ^ rhs.shorten,
+            steps: self.steps ^ rhs.steps,
+            termial: self.termial ^ rhs.termial,
+            no_note: self.no_note ^ rhs.no_note,
+        }
+    }
+}
 #[allow(dead_code)]
 impl Commands {
     pub(crate) const NONE: Self = Self {
@@ -160,7 +171,7 @@ impl RedditComment {
         subreddit: &str,
         pre_commands: Commands,
     ) -> Self {
-        let commands: Commands = Commands::from_comment_text(comment_text) | pre_commands;
+        let commands: Commands = Commands::from_comment_text(comment_text) ^ pre_commands;
 
         let mut status: Status = Default::default();
 
@@ -824,7 +835,7 @@ mod tests {
             "123",
             "test_author",
             "test_subreddit",
-            false,
+            Commands::NONE,
         );
         assert_eq!(comment.calculation_list, []);
         assert_eq!(comment.status, Status::NO_FACTORIAL);

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -160,7 +160,7 @@ impl Commands {
             steps: !(Self::contains_command_format(text, "no steps")
                 | Self::contains_command_format(text, "no_steps")),
             termial: !(Self::contains_command_format(text, "no termial")
-                | Self::contains_command_format(text, "no_steps")),
+                | Self::contains_command_format(text, "no_termial")),
             no_note: !Self::contains_command_format(text, "note"),
         }
     }
@@ -950,7 +950,42 @@ mod tests {
             Commands::NONE,
         );
         let reply = comment.get_reply();
-        assert_eq!(reply, "The factorial of 200 is roughly 7.886578673647905035523632139322 × 10^374 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*");
+        assert_eq!(
+            reply,
+            "The factorial of 200 is roughly 7.886578673647905035523632139322 × 10^374 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
+    fn test_command_termial() {
+        let comment = RedditComment::new(
+            "This comment would like the short version of this factorial 2? \\[termial\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::NONE,
+        );
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "The termial of 2 is 3 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
+    fn test_command_no_note() {
+        let comment = RedditComment::new(
+            "This comment would like the short version of this factorial 10939742352358! \\[no_note\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::NONE,
+        );
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "The factorial of 10939742352358 is approximately 4.451909479489793 × 10^137892308399887 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
     }
 
     #[test]
@@ -960,10 +995,73 @@ mod tests {
             "123",
             "test_author",
             "test_subreddit",
-            Commands::NONE
+            Commands::NONE,
         );
         let reply = comment.get_reply();
-        assert_eq!(reply, "The factorial of 3 is 6 \n\nThe factorial of the factorial of 3 is 720 \n\nThe factorial of the factorial of the factorial of 3 is roughly 2.601218943565795100204903227081 × 10^1746 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*");
+        assert_eq!(
+            reply,
+            "The factorial of 3 is 6 \n\nThe factorial of the factorial of 3 is 720 \n\nThe factorial of the factorial of the factorial of 3 is roughly 2.601218943565795100204903227081 × 10^1746 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
+    fn test_command_long() {
+        let comment = RedditComment::new(
+            "This comment would like the short version of this factorial 200! \\[long\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::SHORTEN,
+        );
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "The factorial of 200 is 788657867364790503552363213932185062295135977687173263294742533244359449963403342920304284011984623904177212138919638830257642790242637105061926624952829931113462857270763317237396988943922445621451664240254033291864131227428294853277524242407573903240321257405579568660226031904170324062351700858796178922222789623703897374720000000000000000000000000000000000000000000000000 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
+    fn test_command_no_termial() {
+        let comment = RedditComment::new(
+            "This comment would like the short version of this factorial 2? \\[no termial\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::TERMIAL,
+        );
+        assert_eq!(comment.status, Status::NO_FACTORIAL);
+    }
+
+    #[test]
+    fn test_command_note() {
+        let comment = RedditComment::new(
+            "This comment would like the short version of this factorial 10939742352358! \\[note\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::NO_NOTE,
+        );
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "Sorry, that is so large, that I can't calculate it, so I'll have to approximate.\n\nThe factorial of 10939742352358 is approximately 4.451909479489793 × 10^137892308399887 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
+    fn test_command_no_steps() {
+        let comment = RedditComment::new(
+            "This comment would like to know all the steps to this factorial chain ((3!)!)! \\[no steps\\] \\[short\\]",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::STEPS,
+        );
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "The factorial of the factorial of the factorial of 3 is roughly 2.601218943565795100204903227081 × 10^1746 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Just as an Idea: To reduce perceived spam, some Subreddits might prefer all comments shortened, or, a command I just added, not display the note, but just the result always. Other (future) commands may be wanted too, so being able to change specific settings on specific Subreddits would be nice. This is what I did here.

Further:
- [ ] Combine commands with xor, so that people can opt out of the Subreddit settings.
- [x] Add negated override commands.
- [x] Merge into SUBREDDITS var 

Again, just an Idea, that I did out of boredom, don't merge if you don't think it fits.