### PR TITLE
Fix multifactorials of negatives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.4.1"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,11 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-<<<<<<< HEAD
-version = "2.3.1"
-=======
-version = "2.4.0"
->>>>>>> master
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.4.2"
+version = "2.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/math.rs
+++ b/src/math.rs
@@ -2,6 +2,7 @@
 use rug::integer::IntegerExt64;
 use rug::ops::*;
 use rug::{Complete, Float, Integer};
+use std::ops::Rem;
 use std::sync::LazyLock;
 
 pub const FLOAT_PRECISION: u32 = 1024;
@@ -11,6 +12,20 @@ pub static LN10: LazyLock<Float> = LazyLock::new(|| Float::with_val(FLOAT_PRECIS
 
 pub fn factorial(n: u64, k: i32) -> Integer {
     Integer::factorial_m_64(n, k as u64).complete()
+}
+
+pub(crate) fn negative_multifacorial_factor(n: Integer, k: i32) -> Option<Integer> {
+    let n = -n;
+    let rem = n.rem(2 * k);
+    if rem == 0 {
+        None
+    } else if rem < k {
+        Some(Integer::ONE.clone())
+    } else if rem == k {
+        None
+    } else {
+        Some(Integer::NEG_ONE.clone())
+    }
 }
 
 pub(crate) fn subfactorial(n: u64) -> Integer {
@@ -171,7 +186,7 @@ pub fn approximate_termial_digits(n: Integer) -> Integer {
 ///
 /// # Panic
 /// Will panic if `x` is not finite.
-fn adjust_approximate((x, e): (Float, Integer)) -> (Float, Integer) {
+pub(crate) fn adjust_approximate((x, e): (Float, Integer)) -> (Float, Integer) {
     let (extra, _) = (x.clone().ln() / &*LN10)
         .to_integer_round(rug::float::Round::Down)
         .expect("Got non-finite number, x is likely not finite");

--- a/src/math.rs
+++ b/src/math.rs
@@ -2,8 +2,8 @@
 use rug::integer::IntegerExt64;
 use rug::ops::*;
 use rug::{Complete, Float, Integer};
-use std::ops::Rem;
 use std::ops::Mul;
+use std::ops::Rem;
 use std::sync::LazyLock;
 
 pub const FLOAT_PRECISION: u32 = 1024;

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -483,9 +483,12 @@ impl RedditComment {
 
 #[cfg(test)]
 mod tests {
-    use rug::Integer;
+    use rug::{Float, Integer};
 
-    use crate::{calculation_results::CalculationResult, math};
+    use crate::{
+        calculation_results::CalculationResult,
+        math::{self, FLOAT_PRECISION},
+    };
 
     use super::*;
 
@@ -702,7 +705,7 @@ mod tests {
     #[test]
     fn test_comment_new_of_negative() {
         let comment = RedditComment::new(
-            "This is a spoiler comment (-5)!",
+            "This is a spoiler comment (-5)! (-5)!! (-5)!!!! (-5)!!!!!",
             "123",
             "test_author",
             "test_subreddit",
@@ -711,11 +714,30 @@ mod tests {
 
         assert_eq!(
             comment.calculation_list,
-            vec![Calculation {
-                value: (-5).into(),
-                steps: vec![(1, 0)],
-                result: CalculationResult::ComplexInfinity,
-            }]
+            vec![
+                Calculation {
+                    value: (-5).into(),
+                    steps: vec![(1, 0)],
+                    result: CalculationResult::ComplexInfinity,
+                },
+                Calculation {
+                    value: (-5).into(),
+                    steps: vec![(2, 0)],
+                    result: CalculationResult::Float(
+                        Float::with_val(FLOAT_PRECISION, 3).recip().into()
+                    ),
+                },
+                Calculation {
+                    value: (-5).into(),
+                    steps: vec![(4, 0)],
+                    result: CalculationResult::Exact((-1).into()),
+                },
+                Calculation {
+                    value: (-5).into(),
+                    steps: vec![(5, 0)],
+                    result: CalculationResult::ComplexInfinity,
+                }
+            ]
         );
     }
 


### PR DESCRIPTION
Multifactorials of negative numbers were previously handled wrong. This introduces the handling for those numbers.

Further:
- [x]  Handle tower result (don't return 0 digits)

Resolves: #123 