### PR TITLE
Fix subreddits with no commands resulting in empty string sub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let subreddit_commands = subreddit_commands.leak();
     let commands = subreddit_commands
         .split('+')
-        .map(|s| s.split_once(':').unwrap_or_default())
+        .map(|s| s.split_once(':').unwrap_or((s, "")))
         .map(|(sub, commands)| {
             (
                 sub,


### PR DESCRIPTION
This should hopefully fix the issue you had with deployment.

The problem was, that `unwrap_or_default` was used, where `unwrap_or` was needed, discarding subreddits without commands and returning a subreddit of empty string instead.