### PR TITLE
Deploy the current commit instead of master

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,23 +25,27 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     name: Deploy to Server
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://example.com
 
     steps:
       - name: SSH into Server and Deploy
         env:
+          DEPLOY_COMMIT: ${{ github.event.inputs.commit }}
           PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_PATH: ${{ secrets.SSH_PATH }}
         run: |
-          echo "$PRIVATE_KEY" > private_key.pem # Write the private key to a file
-          chmod 600 private_key.pem # Set the appropriate permissions for the key file
+          echo "$PRIVATE_KEY" > private_key.pem
+          chmod 600 private_key.pem
 
           ssh -o StrictHostKeyChecking=no -i private_key.pem $SSH_USER@$SSH_HOST <<EOF
             set -e  # Exit immediately if a command fails
             cd $SSH_PATH && \
             git fetch origin master && \
-            git reset --hard origin/master  && \
+            git reset --hard "$DEPLOY_COMMIT"  && \
             docker build -t factorion-bot . && \
             docker stop factorion-bot || true && \
             sleep 3 && \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
That way rollbacks should be made possible as we'll take the sha of the commit when resetting, instead of HEAD master.