### PR TITLE
Weed comments without ! or ?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.5"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.2"
+version = "2.5.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.5"
+version = "2.5.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -239,6 +239,10 @@ impl RedditComment {
     }
 
     fn extract_calculation_jobs(text: &str, include_termial: bool) -> Vec<CalculationJob> {
+        if !text.contains('!') && !(text.contains('?') && include_termial) {
+            return vec![];
+        }
+
         static FACTORIAL_REGEX: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(r"(?<![,.?!\d-]|!\()(-*|\b)(\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)(!+)(?![<\d]|&lt;|\)?[!?])")
                 .expect("Invalid factorial regex")


### PR DESCRIPTION
At least locally, most time for `get_comments` is spent checking regex. Since most comments do not feature a factorial or even an exclamation mark or question mark at all, we can simply check for those symbols (ignoring question mark if we don't have termial enabled). That way, we should save a bunch of time!