### PR TITLE
Removed deploy dependency on test

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -62,7 +62,6 @@ jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch'
     name: Deploy to Server
-    needs: test
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
Removed deploy dependency on test, since it seems not to work with `github.event_name == 'workflow_dispatch'` as I hoped