### PR TITLE
Calculate sleep time (go more near the reatelimit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.9"
+version = "2.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.9"
+version = "2.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ INFLUXDB_TOKEN=<token>
 Replace with the values you received from the Reddit App creation.
 InfluxDB is optional and can be removed if not needed.
 The `_EVERY` variables are optional and default to "1".
+They control how often posts/mentions are checked compared to comments.
+Setting them to "0" will result in a chrash.
 
 ## Run the following command to install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Replace with the values you received from the Reddit App creation.
 InfluxDB is optional and can be removed if not needed.
 The `_EVERY` variables are optional and default to "1".
 They control how often posts/mentions are checked compared to comments.
-Setting them to "0" will result in a chrash.
+Setting them to "0" will result in a crash.
 
 ## Run the following command to install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ cd factorion-bot
 Create a `.env` file in the project root with the following variables:
 
 ```env
-CLIENT_ID=<your_client_id>
-CLIENT_SECRET=<your_client_secret>
+APP_CLIENT_ID=<your_client_id>
+APP_SECRET=<your_client_secret>
 
-USERNAME=<reddit_app_username>
-PASSWORD=<reddit_app_password>
+REDDIT_USERNAME=<reddit_app_username>
+REDDIT_PASSWORD=<reddit_app_password>
 
 SLEEP_BETWEEN_REQUESTS=<sleep_time>
 SUBREDDITS=<subreddits>

--- a/README.md
+++ b/README.md
@@ -78,14 +78,19 @@ PASSWORD=<reddit_app_password>
 SLEEP_BETWEEN_REQUESTS=<sleep_time>
 SUBREDDITS=<subreddits>
 TERMIAL_SUBREDDITS=<subbreddits_with_termials>
-CHECK_MENTIONS=<ignore_mentions>
+CHECK_MENTIONS=<check_mentions>
+CHECK_POSTS=<check_posts>
+MENTIONS_EVERY=<check_mentions_every_nth_loop>
+POSTS_EVERY=<check_posts_every_nth_loop>
 
 INFLUXDB_HOST=localhost:8889
 INFLUXDB_BUCKET=factorion-test
 INFLUXDB_TOKEN=<token>
 ```
 
-Replace with the values you received from the Reddit App creation. InfluxDB is optional and can be removed if not needed.
+Replace with the values you received from the Reddit App creation.
+InfluxDB is optional and can be removed if not needed.
+The `_EVERY` variables are optional and default to "1".
 
 ## Run the following command to install dependencies:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let commands = subreddit_commands
         .split('+')
         .map(|s| s.split_once(':').unwrap_or((s, "")))
+        .filter(|s| s.0 != "")
         .map(|(sub, commands)| {
             (
                 sub,
@@ -202,7 +203,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if should_answer {
                 let Ok(reply): Result<String, _> = std::panic::catch_unwind(|| comment.get_reply())
                 else {
-                    eprintln!("Failed to format comment!");
+                    println!("Failed to format comment!");
                     continue;
                 };
                 // Sleep to not spam comments too quickly

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,12 +244,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let sleep_between_requests = if rate.1 < requests_per_loop + 1.0 {
             rate.0 + 5.0
         } else if rate.1 < requests_per_loop * 4.0 {
-            rate.0 / rate.1 + 2.0
+            rate.0 / rate.1 + 5.0
         } else {
-            ((rate.0 / rate.1) - 2.0).max(2.0)
+            (rate.0 / rate.1).max(2.0) + 1.0
         };
         // Sleep to avoid hitting API rate limits
-        sleep(Duration::from_secs(sleep_between_requests as u64)).await;
+        sleep(Duration::from_secs(sleep_between_requests.ceil() as u64)).await;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,11 +242,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         influxdb::log_time_consumed(influx_client, start, end, "comment_loop").await?;
 
         let sleep_between_requests = if rate.1 < requests_per_loop + 1.0 {
-            rate.0 + 5.0
-        } else if rate.1 < requests_per_loop * 4.0 {
-            rate.0 / rate.1 + 5.0
+            rate.0 + 1.0
         } else {
-            (rate.0 / rate.1).max(2.0) + 1.0
+            (rate.0 / rate.1 * requests_per_loop).max(2.0) + 1.0
         };
         // Sleep to avoid hitting API rate limits
         sleep(Duration::from_secs(sleep_between_requests.ceil() as u64)).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .lines()
         .map(|s| s.to_string())
         .collect::<Vec<String>>();
+    let mut last_ids = Default::default();
 
     // Polling Reddit for new comments
     loop {
@@ -102,7 +103,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         let start = SystemTime::now();
         let (comments, mut rate) = reddit_client
-            .get_comments(&mut already_replied_or_rejected, check_mentions)
+            .get_comments(
+                &mut already_replied_or_rejected,
+                check_mentions,
+                &mut last_ids,
+            )
             .await
             .unwrap_or_default();
         let end = SystemTime::now();

--- a/src/math.rs
+++ b/src/math.rs
@@ -69,10 +69,7 @@ fn fractional_multifactorial_product(x: Float, _k: i32, k: Float) -> Float {
     (1.._k)
         .map(|j| {
             let exp = fractional_multifactorial_sum(x.clone(), j, _k, k.clone());
-            (j.clone()
-                / k.clone().pow(j.clone() / k.clone())
-                / fractional_factorial(j.clone() / k.clone()))
-            .pow(exp)
+            (j / k.clone().pow(j / k.clone()) / fractional_factorial(j / k.clone())).pow(exp)
         })
         .reduce(Mul::mul)
         .unwrap_or(Float::with_val(FLOAT_PRECISION, 1))

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -164,7 +164,7 @@ impl RedditClient {
                             .expect("Comment count uninitialized")
                             .to_string(),
                     ),
-                    ("after", after),
+                    ("before", after),
                 ])
             }
         }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -579,7 +579,7 @@ impl RedditClient {
             }
             comments.push(extracted_comment);
         }
-        let id = comments.last().map(|comment| comment.id.clone());
+        let id = comments.first().map(|comment| comment.id.clone());
 
         Ok((comments, parent_paths, (reset, remaining), id))
     }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -614,7 +614,7 @@ impl RedditClient {
                     } | commands.get(subreddit).copied().unwrap_or(Commands::NONE),
                 )
             }) else {
-                println!("Failed to construct comment!");
+                println!("Failed to construct comment {comment_id}!");
                 return None;
             };
             if let Some((mention, commands, mention_author)) = mention_map.get(comment_id) {
@@ -657,7 +657,7 @@ impl RedditClient {
                         commands.get(subreddit).copied().unwrap_or(Commands::NONE),
                     )
                 }) else {
-                    println!("Failed to construct comment!");
+                    println!("Failed to construct comment {post_id}!");
                     return None;
                 };
 

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -573,8 +573,8 @@ impl RedditClient {
                 continue;
             };
             if is_mention
-                && extracted_comment.status.no_factorial
                 && !extracted_comment.status.already_replied_or_rejected
+                && extracted_comment.status.no_factorial
             {
                 if let Some(path) = Self::extract_summon_parent_id(comment) {
                     parent_paths.push((

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -145,14 +145,19 @@ impl RedditClient {
         let mut time = (u64::MAX, u64::MIN);
 
         let (subs_response, posts_response, mentions_response) = join!(
-            OptionFuture::from(SUBREDDIT_URL.clone().map(|mut subreddit_url| {
-                subreddit_url.set_query(Some(&format!(
-                    "limit={}&after={}",
-                    COMMENT_COUNT.get().expect("Comment count uninitialized"),
-                    last_ids.0
-                )));
+            OptionFuture::from(SUBREDDIT_URL.clone().map(|subreddit_url| {
                 self.client
                     .get(subreddit_url)
+                    .query(&[
+                        (
+                            "limit",
+                            &COMMENT_COUNT
+                                .get()
+                                .expect("Comment count uninitialized")
+                                .to_string(),
+                        ),
+                        ("after", &last_ids.0),
+                    ])
                     .bearer_auth(&self.token.access_token)
                     .send()
             })),
@@ -160,27 +165,37 @@ impl RedditClient {
                 check_posts
                     .then_some(SUBREDDIT_POSTS_URL.clone())
                     .flatten()
-                    .map(|mut subreddit_url| {
-                        subreddit_url.set_query(Some(&format!(
-                            "limit={}&after={}",
-                            COMMENT_COUNT.get().expect("Comment count uninitialized"),
-                            last_ids.1
-                        )));
+                    .map(|subreddit_url| {
                         self.client
                             .get(subreddit_url)
+                            .query(&[
+                                (
+                                    "limit",
+                                    &COMMENT_COUNT
+                                        .get()
+                                        .expect("Comment count uninitialized")
+                                        .to_string(),
+                                ),
+                                ("after", &last_ids.1),
+                            ])
                             .bearer_auth(&self.token.access_token)
                             .send()
                     })
             ),
             OptionFuture::from(check_mentions.then_some(MENTION_URL.clone()).map(
-                |mut subreddit_url| {
-                    subreddit_url.set_query(Some(&format!(
-                        "limit={}&after={}",
-                        COMMENT_COUNT.get().expect("Comment count uninitialized"),
-                        last_ids.2
-                    )));
+                |subreddit_url| {
                     self.client
                         .get(subreddit_url)
+                        .query(&[
+                            (
+                                "limit",
+                                &COMMENT_COUNT
+                                    .get()
+                                    .expect("Comment count uninitialized")
+                                    .to_string(),
+                            ),
+                            ("after", &last_ids.2),
+                        ])
                         .bearer_auth(&self.token.access_token)
                         .send()
                 }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -792,10 +792,10 @@ mod tests {
         let (status, comments) = join!(
             async {
                 dummy_server(&[(
-                    "GET /r/test_subreddit/comments?limit=100&after=t1_m86nsre HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
+                    "GET /r/test_subreddit/comments?limit=100&before=t1_m86nsre HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
                     "HTTP/1.1 200 OK\r\nx-ratelimit-remaining: 10\r\nx-ratelimit-reset: 200\n\n{\"data\":{\"children\":[]}}"
                 ),(
-                    "GET /r/post_subreddit+test_subreddit/new?limit=100&after=t3_83us27sa HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
+                    "GET /r/post_subreddit+test_subreddit/new?limit=100&before=t3_83us27sa HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
                     "HTTP/1.1 200 OK\r\nx-ratelimit-remaining: 9\r\nx-ratelimit-reset: 200\n\n{\"data\":{\"children\":[]}}"
                 ),(
                     "GET /message/mentions?limit=100 HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -984,7 +984,7 @@ mod tests {
         );
         println!("{:#?}", comments);
         assert_eq!(t, (350.0, 10.0));
-        assert_eq!(id.unwrap(), "t1_m38msun");
+        assert_eq!(id.unwrap(), "t3_m38msum");
     }
 
     #[test]

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -239,7 +239,7 @@ impl RedditComment {
     }
 
     fn extract_calculation_jobs(text: &str, include_termial: bool) -> Vec<CalculationJob> {
-        if !text.contains('!') && !(text.contains('?') && include_termial) {
+        if !(text.contains('!') || text.contains('?') && include_termial) {
             return vec![];
         }
 

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -206,32 +206,10 @@ impl RedditCommentConstructed {
 
         let mut status: Status = Default::default();
 
-        let pending_list: Vec<CalculationJob> =
-            Self::extract_calculation_jobs(comment_text, commands.termial);
-
-        let mut calculation_list: Vec<Calculation> = pending_list
-            .into_iter()
-            .flat_map(|calc| calc.execute(commands.steps))
-            .filter_map(|x| {
-                if x.is_none() {
-                    status.number_too_big_to_calculate = true;
-                };
-                x
-            })
-            .collect();
-
-        calculation_list.sort();
-        calculation_list.dedup();
-        calculation_list.sort_by_key(|x| x.steps.len());
-
-        if calculation_list.is_empty() {
-            status.no_factorial = true;
-        } else {
-            status.factorials_found = true;
-        }
-        let text = if comment_text.contains('!') || comment_text.contains('?') {
+        let text = if Self::might_have_factorial(comment_text) {
             comment_text.to_owned()
         } else {
+            status.no_factorial = true;
             String::new()
         };
 
@@ -246,6 +224,42 @@ impl RedditCommentConstructed {
         }
     }
 
+    pub fn might_have_factorial(text: &str) -> bool {
+        text.contains(")!")
+            || text.contains("!(")
+            || text.contains(")?")
+            || text.contains("0!")
+            || text.contains("1!")
+            || text.contains("2!")
+            || text.contains("3!")
+            || text.contains("4!")
+            || text.contains("5!")
+            || text.contains("6!")
+            || text.contains("7!")
+            || text.contains("8!")
+            || text.contains("9!")
+            || text.contains("!0")
+            || text.contains("!1")
+            || text.contains("!2")
+            || text.contains("!3")
+            || text.contains("!4")
+            || text.contains("!5")
+            || text.contains("!6")
+            || text.contains("!7")
+            || text.contains("!8")
+            || text.contains("!9")
+            || text.contains("0?")
+            || text.contains("1?")
+            || text.contains("2?")
+            || text.contains("3?")
+            || text.contains("4?")
+            || text.contains("5?")
+            || text.contains("6?")
+            || text.contains("7?")
+            || text.contains("8?")
+            || text.contains("9?")
+    }
+
     pub fn extract(self) -> RedditComment<Vec<CalculationJob>> {
         let RedditComment {
             id,
@@ -253,11 +267,15 @@ impl RedditCommentConstructed {
             author,
             notify,
             subreddit,
-            status,
+            mut status,
             commands,
         } = self;
         let pending_list: Vec<CalculationJob> =
             Self::extract_calculation_jobs(&comment_text, commands.termial);
+
+        if pending_list.is_empty() {
+            status.no_factorial = true;
+        }
 
         RedditComment {
             id,


### PR DESCRIPTION
The Reddit API allows 100 requests per minute, we currently do only little more than 3 on average as mentions are rare (one more request then) and most comments do not lead to a reply. To get closer without accidentally going over the limit, I implemented this automatic sleep calculation based on `X-Ratelimit-Remaining` and `X-Ratelimit-Reset`.

During normal operation, it waits a little less on comments than calculated (reset/remaining) to make up for the added delay of get_comments and rapidly replies (every 2 seconds). If it is close to running out, it adds some extra delay and uses a calculated wait for replies. If it runs out (could request too much), it waits a little more than the reset time.

As this would normally recheck comments even more, I used the `after` parameter to only fetch new comments/posts/mentions.

Further:
- [ ] Test and tweak the delay calculation
- [x] Check performance of `after` (whether url query parsing takes less time than checking 100 comments)
- [x] Implement checking posts and mentions less often (every nth loop)

Resolves #49
Resolves #12