### PR TITLE
Seperate out RedditComment steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.9"
+version = "2.5.10"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.9"
+version = "2.5.10"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use core::panic;
 use dotenvy::dotenv;
 use influxdb::INFLUX_CLIENT;
 use reddit_api::RedditClient;
-use reddit_comment::{Commands, Status};
+use reddit_comment::{Commands, RedditComment, Status};
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::{self, OpenOptions};
@@ -102,6 +102,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let end = SystemTime::now();
 
         influxdb::log_time_consumed(influx_client, start, end, "get_comments").await?;
+
+        let start = SystemTime::now();
+        let comments = comments
+            .into_iter()
+            .map(RedditComment::extract)
+            .collect::<Vec<_>>();
+        let end = SystemTime::now();
+
+        influxdb::log_time_consumed(influx_client, start, end, "extract_factorials").await?;
+
+        let start = SystemTime::now();
+        let comments = comments
+            .into_iter()
+            .map(RedditComment::calc)
+            .collect::<Vec<_>>();
+        let end = SystemTime::now();
+
+        influxdb::log_time_consumed(influx_client, start, end, "calculate_factorials").await?;
 
         let start = SystemTime::now();
         for comment in comments {

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -229,13 +229,18 @@ impl RedditCommentConstructed {
         } else {
             status.factorials_found = true;
         }
+        let text = if comment_text.contains('!') || comment_text.contains('?') {
+            comment_text.to_owned()
+        } else {
+            String::new()
+        };
 
         RedditComment {
             id: id.to_string(),
             author: author.to_string(),
             notify: None,
             subreddit: subreddit.to_string(),
-            calculation_list: comment_text.to_owned(),
+            calculation_list: text,
             status,
             commands,
         }


### PR DESCRIPTION
This seperates the RedditComment into steps using typestates, it now has three states:
1. Constructed - Contains the comment text, can be `extract`ed. (Commands are already checked here)
2. Extracted - Contains a list of calulation jobs, can be `calc`ulated.
3. Calculated - Contains a list of calculations, can `get_reply`.

A status can be added at any point. Type aliases are provided for convenience. Performance impact should be negligible, it adds two allocations per loop and one per comment (the text, might be possible to optimize).

I also have already made use of this in `main`, the extraction time and calculation time are also logged. (Please check if I did that correctly and tell me what the metric names should be) This also fixes a bug:

Resolves #149 