### PR TITLE
Large exponentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.10"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.11"
+version = "2.5.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_tasks.rs
+++ b/src/calculation_tasks.rs
@@ -27,6 +27,8 @@ pub(crate) static UPPER_TERMIAL_APPROXIMATION_LIMIT: LazyLock<Float> = LazyLock:
     max
 });
 
+pub(crate) const INTEGER_CONSTRUCTION_LIMIT: i64 = 1_000_000_000;
+
 pub(crate) static TOO_BIG_NUMBER: LazyLock<Integer> =
     LazyLock::new(|| Integer::from_str(&format!("1{}", "0".repeat(9999))).unwrap());
 


### PR DESCRIPTION
Handle exponentials that result in an integer. This manually calculates those into integers, preserving the number in the reply perfectly. I added a limit to the size of these integers, as too large numbers use up both ram and cpu, currently set to 1_000_000_000 (exponent).

Resolves #147 