### PR TITLE
Fix decimal multifactorial performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.10"
+version = "2.5.12"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.12"
+version = "2.5.13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.11"
+version = "2.5.12"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.12"
+version = "2.5.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_tasks.rs
+++ b/src/calculation_tasks.rs
@@ -27,6 +27,8 @@ pub(crate) static UPPER_TERMIAL_APPROXIMATION_LIMIT: LazyLock<Float> = LazyLock:
     max
 });
 
+pub(crate) const UPPER_DECIMAL_MULTIFATORIAL_K_LIMIT: i32 = 50;
+
 pub(crate) static TOO_BIG_NUMBER: LazyLock<Integer> =
     LazyLock::new(|| Integer::from_str(&format!("1{}", "0".repeat(9999))).unwrap());
 
@@ -193,7 +195,7 @@ impl CalculationJob {
                         num.as_float().to_integer()?
                     }
                 }
-                k => {
+                k if k < UPPER_DECIMAL_MULTIFATORIAL_K_LIMIT => {
                     let res: Float = math::fractional_multifactorial(num.as_float().clone(), k)
                         * if negative % 2 != 0 { -1 } else { 1 };
                     if res.is_finite() {
@@ -206,6 +208,7 @@ impl CalculationJob {
                         num.as_float().to_integer()?
                     }
                 }
+                _ => num.as_float().to_integer()?,
             },
             Number::Int(num) => num.clone(),
         };

--- a/src/math.rs
+++ b/src/math.rs
@@ -180,11 +180,10 @@ fn approximate_factorial_inner(n: Float) -> (Float, Integer) {
 /// Will panic if either k or n are 0.
 pub fn approximate_multifactorial(n: Integer, k: i32) -> (Float, Integer) {
     let n = Float::with_val(FLOAT_PRECISION, n);
-    let _k = k;
     let k = Float::with_val(FLOAT_PRECISION, k);
     let fact = approximate_factorial_inner(n.clone() / k.clone());
     let pow = approximate_multifactorial_pow(n.clone(), k.clone());
-    let t = fractional_multifactorial_product(n, _k, k);
+    let t = approximate_multifactorial_product(n, k);
     adjust_approximate((fact.0 * pow.0 * t, fact.1 + pow.1))
 }
 fn approximate_multifactorial_pow(n: Float, k: Float) -> (Float, Integer) {
@@ -196,6 +195,10 @@ fn approximate_multifactorial_pow(n: Float, k: Float) -> (Float, Integer) {
         .0;
     let x = k.pow(base - e.clone() / k_log10);
     (x, e)
+}
+fn approximate_multifactorial_product(n: Float, k: Float) -> Float {
+    let j: Float = ((n - 1) as Float).rem(&k) + 1;
+    j.clone() / k.clone().pow(j.clone() / k.clone()) / fractional_factorial(j.clone() / k.clone())
 }
 
 pub fn approximate_subfactorial(n: Integer) -> (Float, Integer) {


### PR DESCRIPTION
As I figured out the performance impact of high-k deciaml mutifactorials to be significant, I added a limit to them. To exempt approximate multifactorials from that limit, I simplified the "product", making its impact constant.

Resolves #153 