### PR TITLE
Optimize decimal multifactorial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.13"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.15"
+version = "2.5.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.14"
+version = "2.5.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_tasks.rs
+++ b/src/calculation_tasks.rs
@@ -27,7 +27,6 @@ pub(crate) static UPPER_TERMIAL_APPROXIMATION_LIMIT: LazyLock<Float> = LazyLock:
     max
 });
 
-pub(crate) const UPPER_DECIMAL_MULTIFATORIAL_K_LIMIT: i32 = 50;
 pub(crate) const INTEGER_CONSTRUCTION_LIMIT: i64 = 1_000_000_000;
 pub(crate) static TOO_BIG_NUMBER: LazyLock<Integer> =
     LazyLock::new(|| Integer::from_str(&format!("1{}", "0".repeat(9999))).unwrap());
@@ -195,7 +194,7 @@ impl CalculationJob {
                         num.as_float().to_integer()?
                     }
                 }
-                k if k < UPPER_DECIMAL_MULTIFATORIAL_K_LIMIT => {
+                k => {
                     let res: Float = math::fractional_multifactorial(num.as_float().clone(), k)
                         * if negative % 2 != 0 { -1 } else { 1 };
                     if res.is_finite() {
@@ -208,7 +207,6 @@ impl CalculationJob {
                         num.as_float().to_integer()?
                     }
                 }
-                _ => num.as_float().to_integer()?,
             },
             Number::Int(num) => num.clone(),
         };

--- a/src/math.rs
+++ b/src/math.rs
@@ -61,7 +61,11 @@ pub(crate) fn fractional_multifactorial(x: Float, k: i32) -> Float {
     let k = Float::with_val(FLOAT_PRECISION, k);
     let fact = fractional_factorial(x.clone() / k.clone());
     let pow = k.clone().pow(x.clone() / k.clone());
-    let t = fractional_multifactorial_product(x, _k, k);
+    let t = if _k <= 7 {
+        fractional_multifactorial_product(x, _k, k)
+    } else {
+        fractional_multifactorial_product_fast(x, _k, k)
+    };
     fact * pow * t
 }
 
@@ -69,10 +73,24 @@ fn fractional_multifactorial_product(x: Float, _k: i32, k: Float) -> Float {
     (1.._k)
         .map(|j| {
             let exp = fractional_multifactorial_sum(x.clone(), j, _k, k.clone());
-            (j.clone()
-                / k.clone().pow(j.clone() / k.clone())
-                / fractional_factorial(j.clone() / k.clone()))
-            .pow(exp)
+            (j / k.clone().pow(j / k.clone()) / fractional_factorial(j / k.clone())).pow(exp)
+        })
+        .reduce(Mul::mul)
+        .unwrap_or(Float::with_val(FLOAT_PRECISION, 1))
+}
+
+fn fractional_multifactorial_product_fast(x: Float, _k: i32, k: Float) -> Float {
+    (-3..=3)
+        .map(|n| {
+            ((x.to_integer().unwrap() + n - 1) as Integer)
+                .rem(_k - 1)
+                .to_i32()
+                .unwrap()
+                + 1
+        })
+        .map(|j| {
+            let exp = fractional_multifactorial_sum(x.clone(), j, _k, k.clone());
+            (j / k.clone().pow(j / k.clone()) / fractional_factorial(j / k.clone())).pow(exp)
         })
         .reduce(Mul::mul)
         .unwrap_or(Float::with_val(FLOAT_PRECISION, 1))
@@ -592,6 +610,18 @@ mod tests {
             fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 5).to_f64(),
             1.7184810657031144e62
         );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 2.6), 5).to_f64(),
+            2.4698196281039353
+        );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 50).to_f64(),
+            28560000.0
+        );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 100).to_f64(),
+            11900.0
+        );
     }
     #[test]
     #[ignore = "future_improvement"]
@@ -639,6 +669,18 @@ mod tests {
         assert_eq!(
             fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 5).to_f64(),
             1.7184810657031144e62
+        );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 2.6), 5).to_f64(),
+            2.4698196281039353
+        );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 50).to_f64(),
+            28560000.0
+        );
+        assert_eq!(
+            fractional_multifactorial(Float::with_val(FLOAT_PRECISION, 170), 100).to_f64(),
+            11900.0
         );
     }
 


### PR DESCRIPTION
I noticed, that the formula for multifactorials really only cares about the factors with j near x. This means we can just calculate that part, making the function constant w.r.t. k. This also removes the k limit on decimal multifactorials.

Tested with 100-factorial of 170 and 50-factorial of 170 and 5-factorial of 170 and 2.6.