### PR TITLE
Improve performance of tower formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.15"
+version = "2.5.16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.5.13"
+version = "2.5.15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.16"
+version = "2.5.17"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.15"
+version = "2.5.16"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.5.14"
+version = "2.5.15"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_results.rs
+++ b/src/calculation_results.rs
@@ -240,20 +240,25 @@ impl Calculation {
                 )
             }
             CalculationResult::ApproximateDigitsTower(negative, depth, exponent) => {
-                let mut s = if self.is_too_long() || force_shorten {
+                let mut s = String::new();
+                let negative = if *negative { "-" } else { "" };
+                if *depth > 0 {
+                    let _ = write!(s, "10^(");
+                }
+                if *depth > 1 {
+                    let _ = s.push_str(&"10\\^".repeat(*depth as usize - 1));
+                    let _ = write!(s, "(");
+                }
+                s.push_str(&if self.is_too_long() || force_shorten {
                     Self::truncate(exponent, false)
                 } else {
                     exponent.to_string()
-                };
-                let negative = if *negative { "-" } else { "" };
-                for i in 0..*depth {
-                    if i == depth.saturating_sub(1) {
-                        s = format!("10^({s})");
-                    } else if i == 0 {
-                        s = format!("10\\^({s}\\)");
-                    } else {
-                        s = format!("10\\^{s}");
-                    }
+                });
+                if *depth > 1 {
+                    let _ = write!(s, "\\)");
+                }
+                if *depth > 0 {
+                    let _ = write!(s, ")");
                 }
                 write!(
                     acc,


### PR DESCRIPTION
As the most likely coulprit for the huge CPU spike is tower formatting, I optimized that, replacing `format!` with `write!` and `push_str`, like this I got it down to less than a millisecond on my machine at max depth (65535).