### PR TITLE
Handle missing/errant "before" value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 if !dont_reply {
                     match reddit_client.reply_to_comment(comment, &reply).await {
                         Ok(t) => {
-                            rate = t;
+                            if let Some(t) = t {
+                                rate = t;
+                            } else {
+                                println!("Missing ratelimit");
+                            }
                             influxdb::log_comment_reply(
                                 influx_client,
                                 &comment_id,

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -579,7 +579,11 @@ impl RedditClient {
             }
             comments.push(extracted_comment);
         }
-        let id = comments.first().map(|comment| comment.id.clone());
+        let id = if comments.is_empty() {
+            Some(String::new())
+        } else {
+            comments.get(1).map(|comment| comment.id.clone())
+        };
 
         Ok((comments, parent_paths, (reset, remaining), id))
     }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -988,7 +988,7 @@ mod tests {
         );
         println!("{:#?}", comments);
         assert_eq!(t, (350.0, 10.0));
-        assert_eq!(id.unwrap(), "t3_m38msum");
+        assert_eq!(id.unwrap(), "t3_m38msug");
     }
 
     #[test]

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -849,7 +849,7 @@ mod tests {
                     "GET /r/post_subreddit+test_subreddit/new?limit=100&before=t3_83us27sa HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
                     "HTTP/1.1 200 OK\r\nx-ratelimit-remaining: 9\r\nx-ratelimit-reset: 200\n\n{\"data\":{\"children\":[]}}"
                 ),(
-                    "GET /message/mentions?limit=100 HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
+                    "GET /message/inbox?limit=100 HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",
                     "HTTP/1.1 200 OK\r\nx-ratelimit-remaining: 8\r\nx-ratelimit-reset: 199\n\n{\"data\":{\"children\":[{\"kind\": \"t1\",\"data\":{\"author\":\"mentioner\",\"body\":\"u/factorion-bot !termial\",\"parent_id\":\"t1_m38msum\"}}]}}"
                 ),(
                     "GET /api/info?id=t1_m38msum HTTP/1.1\r\nauthorization: Bearer token\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\n\r\n",


### PR DESCRIPTION
Should fix the bot not replying in some cases. If the `before` value was wrong, it resets it, to disable it on the next try. To do that, it always checks after the second-newest comment, so that the length of replies should stay 1.

Resolves #160 
(hopefully)