### PR TITLE
Fix indefinite hang after missing ratelimit, safe fallback 600s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.6.2"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.6.3"
+version = "2.6.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -144,7 +144,7 @@ impl RedditClient {
             .expect("Failed to get token");
         }
 
-        let mut time = (f64::MAX, 0.0);
+        let mut time = (600.0, 0.0);
 
         fn add_query(request: RequestBuilder, after: &String) -> RequestBuilder {
             if after.is_empty() {


### PR DESCRIPTION
A simple 1 line fix, that makes the longest sleep before comments 600s (+5s buffer).

Resolves #168 