### PR TITLE
Dont use pretty print to not break logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,15 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "deranged"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
-dependencies = [
- "powerfmt",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.7.3"
+version = "2.7.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -301,7 +292,6 @@ dependencies = [
  "rug",
  "serde",
  "serde_json",
- "time",
  "tokio",
 ]
 
@@ -954,12 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,12 +1049,6 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -1517,25 +1495,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.7.4"
+version = "2.7.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,7 +14,6 @@ tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 num-traits = { version = "0.2.19", default-features = false }
 base64 = { version = "0.22.1", default-features = false }
 dotenvy = "^0.15.7"
-time = "0.3.41"
 chrono = { version = "0.4.40", features = ["now"], default-features = false }
 anyhow = { version = "1.0.97", default-features = false }
 http = { version = "1.3.1", default-features = false }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -385,7 +385,7 @@ impl RedditClient {
 
         if response_status_err {
             error!(
-                "Comment ID {} by {} in {} -> Status FAILED: {:#?}",
+                "Comment ID {} by {} in {} -> Status FAILED: {:?}",
                 comment.id,
                 comment.author,
                 comment.subreddit,
@@ -395,7 +395,7 @@ impl RedditClient {
         }
 
         info!(
-            "Comment ID {} -> Status OK: {:#?}",
+            "Comment ID {} -> Status OK: {:?}",
             comment.id,
             RedditClient::get_error_message(response_json)
         );
@@ -462,7 +462,7 @@ impl RedditClient {
             .await?;
 
         if !response.status().is_success() {
-            error!("Failed to get token: {:#?}", response);
+            error!("Failed to get token: {:?}", response);
             return Err("Failed to get token".into());
         }
 
@@ -471,7 +471,7 @@ impl RedditClient {
         let token_expiration_time = Self::get_expiration_time_from_jwt(&response.access_token);
 
         info!(
-            "Fetched new token. Will expire: {:#?}",
+            "Fetched new token. Will expire: {:?}",
             token_expiration_time
         );
 
@@ -506,7 +506,7 @@ impl RedditClient {
     fn check_response_status(response: &Response) -> Result<(), ()> {
         if !response.status().is_success() {
             error!(
-                "Failed to get comments. Statuscode: {:#?}. Response: {:#?}",
+                "Failed to get comments. Statuscode: {:?}. Response: {:?}",
                 response.status(),
                 response
             );
@@ -950,7 +950,7 @@ mod tests {
                 )
             )]
         );
-        println!("{:#?}", comments);
+        println!("{:?}", comments);
         assert_eq!(comments.2, Some((350.0, 10.0)));
     }
 
@@ -1041,7 +1041,7 @@ mod tests {
                 result: crate::calculation_results::CalculationResult::Exact(1334961.into())
             }]
         );
-        println!("{:#?}", comments);
+        println!("{:?}", comments);
         assert_eq!(t, Some((350.0, 10.0)));
         assert_eq!(id.unwrap(), "t3_m38msug");
     }


### PR DESCRIPTION
Pretty print destroys logs and makes them unusable on pretty printed output

![image](https://github.com/user-attachments/assets/cd5f701c-842e-4299-8bbe-1b2242e9cb8f)
