### PR TITLE
Color log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.7.5"
+version = "2.7.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.7.5"
+version = "2.7.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,9 +236,10 @@ fn init() {
     dotenv().ok();
     env_logger::builder()
         .format(|buf, record| {
+            let style = buf.default_level_style(record.level());
             writeln!(
                 buf,
-                "{} | {} | {} | {}",
+                "{style}{} | {} | {} | {}",
                 record.level(),
                 env!("CARGO_PKG_NAME"),
                 buf.timestamp(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ fn init() {
                 buf,
                 "{style}{} | {} | {} | {}",
                 record.level(),
-                env!("CARGO_PKG_NAME"),
+                record.target(),
                 buf.timestamp(),
                 record.args()
             )


### PR DESCRIPTION
A small change to make use of color in terminal log output. (should not interfere with piped output, if it does, use `RUST_LOG_SYTLE=none`)

Additionally, the target is now used where previously only "factorion-bot" was written. This is a separate commit, so that I can remove it easily, if the change is not wanted.