### PR TITLE
Fix regression on detection of integer decimals (like 0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.7.5"
+version = "2.7.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.7.5"
+version = "2.7.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.7.6"
+version = "2.7.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_results.rs
+++ b/src/calculation_results.rs
@@ -124,6 +124,10 @@ impl FromStr for Number {
         if negative {
             num *= -1;
         }
+        if num.is_integer() {
+            let num = num.to_integer().unwrap();
+            return Ok(Number::Int(num));
+        }
         Ok(Number::Float(num.into()))
     }
 }

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -973,6 +973,27 @@ mod tests {
         assert_eq!(comment.status, Status::FACTORIALS_FOUND);
     }
     #[test]
+    fn test_comment_new_decimal_integer() {
+        let comment = RedditComment::new(
+            "This is a test comment with decimal number 0.0!",
+            "123",
+            "test_author",
+            "test_subreddit",
+            Commands::NONE,
+        )
+        .extract()
+        .calc();
+        assert_eq!(
+            comment.calculation_list,
+            vec![Calculation {
+                value: Number::Int(0.into()),
+                steps: vec![(1, 0)],
+                result: CalculationResult::Exact(1.into())
+            }]
+        );
+        assert_eq!(comment.status, Status::FACTORIALS_FOUND);
+    }
+    #[test]
     fn test_comment_new_decimals_multifactorial() {
         let comment = RedditComment::new(
             "This is a test comment with decimal number 0.5!!",


### PR DESCRIPTION
I noticed, that the bot again wrote "The factorial of 0 is approximately 1" and found, that that check was accidentally removed when we introduced exact "e" integers (`1e10000`). This adds the check for integers back in and adds a test case so that it is not forgotten again.