### PR TITLE
Some code deduplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.7.8"
+version = "2.7.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.7.8"
+version = "2.7.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let commands = subreddit_commands
         .split('+')
         .map(|s| s.split_once(':').unwrap_or((s, "")))
-        .filter(|s| !s.0.is_empty())
+        .filter(|s| !(s.0.is_empty() && s.1.is_empty()))
         .map(|(sub, commands)| {
             (
                 sub,

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -678,7 +678,10 @@ impl RedditClient {
                         Commands::TERMIAL
                     } else {
                         Commands::NONE
-                    } | commands.get(subreddit).copied().unwrap_or(Commands::NONE),
+                    } | commands
+                        .get(subreddit)
+                        .copied()
+                        .unwrap_or(commands.get("").copied().unwrap_or(Commands::NONE)),
                 )
             }) else {
                 error!("Failed to construct comment {comment_id}!");

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -91,7 +91,7 @@ impl RedditClient {
                 .map(|(sub, _)| sub.to_string())
                 .collect::<Vec<_>>();
             subreddits.sort();
-            if !subreddits.is_empty() {
+            if !(subreddits.is_empty() || subreddits == [""]) {
                 Some(
                     Url::parse(&format!(
                         "{}/r/{}/comments",
@@ -115,7 +115,7 @@ impl RedditClient {
                 .map(ToString::to_string)
                 .collect::<Vec<_>>();
             post_subreddits.sort();
-            if !post_subreddits.is_empty() {
+            if !(post_subreddits.is_empty() || post_subreddits == [""]) {
                 Some(
                     Url::parse(&format!(
                         "{}/r/{}/new",


### PR DESCRIPTION
While stress-testing (with all of reddit), I noticed some unnecessary code duplication. The most important improvement is merging the `extract_{comment,post,message}` functions, as they only significantly differed in how they got the comment text. I also made the implementation of #181 generic by using the `log!` macro, which accepts a log level.

In the second commit I added a way to set fallback commands, by ending the `SUBREDDITS` with `+:{commands}`, implicitly using "" as the key. This was done to aid my stress-testing and can be removed by me if unwanted.