### PR TITLE
Fix infinite loop upon ':'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+
+[[package]]
+name = "arbtest"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3be567977128c0f71ad1462d9624ccda712193d124e944252f0c5789a06d46"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +277,7 @@ name = "factorion-bot"
 version = "2.9.5"
 dependencies = [
  "anyhow",
+ "arbtest",
  "base64 0.22.1",
  "chrono",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.9.4"
+version = "2.9.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ rug = { version = "1.27.0", features = ["integer", "float"], default-features = 
 futures = { version = "0.3.31", default-features = false }
 log = { version = "0.4.27" }
 env_logger = { version = "0.11.8"}
+
+[dev-dependencies]
+arbtest = "0.3.2"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,7 +6,7 @@ use crate::{
     math::FLOAT_PRECISION,
 };
 
-const POI_STARTS: [char; 18] = [
+const POI_STARTS: [char; 19] = [
     NEGATION,
     '!', // PREFIX_OPS
     '.', // Decimal separators
@@ -21,6 +21,7 @@ const POI_STARTS: [char; 18] = [
     '7',
     '8',
     '9',
+    URI_POI,
     SPOILER_POI,
     SPOILER_HTML_POI,
     PAREN_START,
@@ -144,9 +145,6 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
             current_negative = 0;
             text = &text[end + 1..];
             continue;
-        } else if text.starts_with(SPOILER_POI) {
-            current_negative = 0;
-            text = &text[1..]
         } else if text.starts_with(SPOILER_HTML_START) {
             // Spoiler (html) (2.)
             let mut end = 0;
@@ -168,9 +166,6 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
             current_negative = 0;
             text = &text[end + 4..];
             continue;
-        } else if text.starts_with(SPOILER_HTML_POI) {
-            current_negative = 0;
-            text = &text[1..]
         } else if text.starts_with(NEGATION) {
             // Negation (3.)
             let end = text.find(|c| c != NEGATION).unwrap_or(text.len());
@@ -302,6 +297,12 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
         } else {
             // Number (7.)
             let Some(num) = parse_num(&mut text) else {
+                // advance one char to avoid loop
+                let mut end = 1;
+                while !text.is_char_boundary(end) {
+                    end += 1;
+                }
+                text = &text[end..];
                 continue;
             };
             // postfix? (7.1.)

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -485,6 +485,7 @@ impl RedditCommentCalculated {
 
 #[cfg(test)]
 mod tests {
+    use arbtest::arbitrary::Arbitrary;
     use rug::{Float, Integer};
 
     use crate::{
@@ -1803,5 +1804,23 @@ mod tests {
 
         let reply = comment.get_reply();
         assert_eq!(reply, "Some of these are so large, that I can't even approximate them well, so I can only give you an approximation on the number of digits.\n\nDouble-factorial of 8 is 384 \n\nThe factorial of 10000 is roughly 2.84625968091705451890641321212 × 10^35659 \n\nThe factorial of 37923648 is approximately 1.760585629143694 × 10^270949892 \n\nDouble-factorial of 283462 has approximately 711238 digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*");
+    }
+
+    #[test]
+    fn test_arbitrary_comment() {
+        arbtest::arbtest(|u| {
+            let text = u.arbitrary()?;
+            let _ = RedditComment::new(
+                text,
+                "id",
+                "author",
+                "subreddit",
+                Commands::from_comment_text(text),
+            )
+            .extract()
+            .calc()
+            .get_reply();
+            Ok(())
+        });
     }
 }


### PR DESCRIPTION
To prevent infinite loops in the parser, I previously also just checked the POI cases (for spoiler tags). This evidently is not a great way to do it, because you may easily forget, like I did with uri skipping.

Here I avoid all such cases, by skipping exactly one char, if we don't get a number in the fallback case.