### PR TITLE
Dense IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /.env
 /.idea/
 cargo-test-*
-comment_ids.txt
+comment_ids

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.9.6"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.9.6"
+version = "3.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod reddit_api;
 pub(crate) mod reddit_comment;
 
 const API_COMMENT_COUNT: u32 = 100;
-const COMMENT_IDS_FILE_PATH: &str = "comment_ids";
+const ALREADY_REPLIED_IDS_FILE_PATH: &str = "already_replied_ids.dat";
 const MAX_ALREADY_REPLIED_LEN: usize = 100_000;
 static COMMENT_COUNT: OnceLock<u32> = OnceLock::new();
 static SUBREDDIT_COMMANDS: OnceLock<HashMap<&str, Commands>> = OnceLock::new();
@@ -275,7 +275,7 @@ fn write_comment_ids(already_replied_or_rejected: &[DenseId]) {
         .create(true)
         .write(true)
         .truncate(true)
-        .open(COMMENT_IDS_FILE_PATH)
+        .open(ALREADY_REPLIED_IDS_FILE_PATH)
         .expect("Unable to open or create file");
 
     let raw = already_replied_or_rejected
@@ -286,7 +286,7 @@ fn write_comment_ids(already_replied_or_rejected: &[DenseId]) {
     file.write_all(&raw).expect("Unable to write to file");
 }
 fn read_comment_ids() -> Vec<DenseId> {
-    let raw = std::fs::read(COMMENT_IDS_FILE_PATH).unwrap_or(Vec::new());
+    let raw = std::fs::read(ALREADY_REPLIED_IDS_FILE_PATH).unwrap_or(Vec::new());
     const DENSE_SIZE: usize = std::mem::size_of::<DenseId>();
     // TODO(optimize): use `as_chunks` if available (1.88.0 and up)
     raw.chunks_exact(DENSE_SIZE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,9 +158,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         if already_replied_or_rejected.len() > MAX_ALREADY_REPLIED_LEN {
             let extra = already_replied_or_rejected.len() - MAX_ALREADY_REPLIED_LEN;
-            for _ in 0..extra {
-                already_replied_or_rejected.remove(0);
-            }
+            already_replied_or_rejected.drain(..extra);
         }
 
         write_comment_ids(&already_replied_or_rejected);
@@ -286,6 +284,7 @@ fn write_comment_ids(already_replied_or_rejected: &[DenseId]) {
 fn read_comment_ids() -> Vec<DenseId> {
     let raw = std::fs::read(COMMENT_IDS_FILE_PATH).unwrap_or(Vec::new());
     const DENSE_SIZE: usize = std::mem::size_of::<DenseId>();
+    // TODO(optimize): use `as_chunks` if available (1.88.0 and up)
     raw.chunks_exact(DENSE_SIZE)
         .map(|bytes| DenseId::from_raw(u64::from_le_bytes(bytes.try_into().unwrap())))
         .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,10 +278,7 @@ fn write_comment_ids(already_replied_or_rejected: &[DenseId]) {
 fn read_comment_ids() -> Vec<DenseId> {
     let raw = std::fs::read(COMMENT_IDS_FILE_PATH).unwrap_or(Vec::new());
     const DENSE_SIZE: usize = std::mem::size_of::<DenseId>();
-    raw.as_chunks::<DENSE_SIZE>()
-        .0
-        .iter()
-        .copied()
-        .map(|bytes| DenseId::from_raw(u64::from_le_bytes(bytes)))
+    raw.chunks_exact(DENSE_SIZE)
+        .map(|bytes| DenseId::from_raw(u64::from_le_bytes(bytes.try_into().unwrap())))
         .collect()
 }


### PR DESCRIPTION
After the recent comment on my last pr, I implemented a version of that. Reddit fullnames are stored for later in a dense representation of a 3 bit tag (the t`n`_ part) at the most significant bits of a `u64`, the rest may be used for the id, which gives us a remaining maximum of 2^61 (= 2305843009213693952) ids. Compared to the current <26*36^6 (=56596340736), that will never run out.

The main benefit is, that now the contains check is a direct simd'd check instead of a strcmp, this should make that part negligible (even with the base36 parsing). I also made sure to reverse the order of those checks, so that the newest ids are checked against first.

The main downside is the switch to a new file format, saving it as a binary sequence instead of lines with strings. To migrate, the easiest approach is to `read_comment_ids` call with:
```rust
read_to_string("comment_ids.txt")
    .unwrap()
    .lines()
    .filter(|s| !s.is_empty())
    .map(|s| s.try_into().unwrap())
    .collect()
```
and run it once, it will automatically save the new format. Note, that now "comment_ids" is used, without the txt extension, as the file does not contain text anymore, but binary data.

Final Questions (to @tolik518):
- [x] Should we keep the automatic removal system?
- [x] Should this be a major version bump?