### PR TITLE
Add missing validations and fix assertion messages' errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "2.9.6"
+version = "2.9.7"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/math.rs
+++ b/src/math.rs
@@ -121,7 +121,7 @@ pub(crate) fn fractional_termial(x: Float) -> Float {
 /// Returns a float with the digits, and an int containing the extra base 10 exponent.
 ///
 /// # Panic
-/// Will panic if `n` is `0`.
+/// Will panic if `n <= 0`.
 ///
 /// Algorithm adapted from [Wikipedia](https://en.wikipedia.org/wiki/Stirling's_approximation) as cc-by-sa-4.0
 pub fn approximate_factorial(n: Integer) -> (Float, Integer) {
@@ -133,7 +133,7 @@ fn approximate_factorial_inner(n: Float) -> (Float, Integer) {
     let ten_in_base = &*LN10 / base.clone().ln();
     let (extra, _) = (n.clone() / ten_in_base.clone())
         .to_integer_round(rug::float::Round::Down)
-        .expect("Got non-finite number, n is likely 0");
+        .expect("Got non-finite number, n is likely non-positive");
     let exponent = n.clone() - ten_in_base * Float::with_val(FLOAT_PRECISION, extra.clone());
     let factorial = base.pow(exponent)
         * (Float::with_val(FLOAT_PRECISION, rug::float::Constant::Pi)
@@ -195,8 +195,9 @@ fn approximate_factorial_inner(n: Float) -> (Float, Integer) {
 /// using the sterling aproximation and the fractional multifactorial algorithm.
 ///
 /// # Panic
-/// Will panic if either k or n are 0.
+/// Will panic if either k or n are non-positive.
 pub fn approximate_multifactorial(n: Integer, k: i32) -> (Float, Integer) {
+    assert!(k > 0, "k must be positive");
     let n = Float::with_val(FLOAT_PRECISION, n);
     let k = Float::with_val(FLOAT_PRECISION, k);
     let fact = approximate_factorial_inner(n.clone() / k.clone());
@@ -248,17 +249,18 @@ pub fn approximate_approx_termial((x, e): (Float, Integer)) -> (Float, Integer) 
 /// This is based on the base 10 logarithm of Sterling's Approximation.
 ///
 /// # Panic
-/// Will panic if either `n` or `k` are `0`.
+/// Will panic if either `n` or `k` are non-positive.
 ///
 /// Algorithm adapted from [Wikipedia](https://en.wikipedia.org/wiki/Stirling's_approximation) as cc-by-sa-4.0
 pub fn approximate_multifactorial_digits(n: Integer, k: i32) -> Integer {
+    assert!(k > 0, "k must be positive");
     let n = Float::with_val(FLOAT_PRECISION, n);
     let k = Float::with_val(FLOAT_PRECISION, k);
     let ln10 = &*LN10;
     let base = n.clone().ln() / ln10;
     ((Float::with_val(FLOAT_PRECISION, 0.5) + n.clone() / k.clone()) * base - n / k / ln10)
         .to_integer_round(rug::float::Round::Down)
-        .expect("Got non-finite number, n or k is likely 0")
+        .expect("Got non-finite number, n is likely non-positive")
         .0
         + Integer::ONE
 }


### PR DESCRIPTION
In src/math.rs,
`fn approximate_factorial` will panic when n < 0, while comment only declare it will panic when n == 0. `.expect("Got non-finite number, n is likely 0");` should also modified to `.expect("Got non-finite number, n is likely non-positive");`.
```rust
/// # Panic
/// Will panic if `n` is `0`.
///
/// Algorithm adapted from [Wikipedia](https://en.wikipedia.org/wiki/Stirling's_approximation) as cc-by-sa-4.0
pub fn approximate_factorial(n: Integer) -> (Float, Integer) {
    let n = Float::with_val(FLOAT_PRECISION, n);
    approximate_factorial_inner(n)
}
fn approximate_factorial_inner(n: Float) -> (Float, Integer) {
    let base = n.clone() / &*E;
    let ten_in_base = &*LN10 / base.clone().ln();
    let (extra, _) = (n.clone() / ten_in_base.clone())
        .to_integer_round(rug::float::Round::Down)
        .expect("Got non-finite number, n is likely 0");
...
}
```
`fn approximate_multifactorial` will panic when n <= 0 or k <= 0, but comment only declare it will panic when n == 0 or k == 0. What's more, when (k < 0 or k = 0) && n > 0, assertion message is all "Got non-finite number, n is likely 0", so I add an assertion `assert!(k > 0, "k must be positive");` at the beginning.
```rust
/// # Panic
/// Will panic if either k or n are 0.
pub fn approximate_multifactorial(n: Integer, k: i32) -> (Float, Integer) {
    let n = Float::with_val(FLOAT_PRECISION, n);
    let k = Float::with_val(FLOAT_PRECISION, k);
    let fact = approximate_factorial_inner(n.clone() / k.clone());
    let pow = approximate_multifactorial_pow(n.clone(), k.clone());
    let t = approximate_multifactorial_product(n, k);
    adjust_approximate((fact.0 * pow.0 * t, fact.1 + pow.1))
}
```
`fn approximate_multifactorial_digits`'s comment only declare it will panic when n == 0 or k == 0.  What's more, it will panic when n <= 0, but when k < 0 and n> 0 it will not panic, and output is < 0(I think this is semantically incorrect). Assertion message "Got non-finite number, n or k is likely 0" is also inadequate, so I add an assertion `assert!(k > 0, "k must be positive");` at the beginning and change assertion message from "Got non-finite number, n or k is likely 0" to "Got non-finite number, n is likely non-positive"(k is checked above).
```rust
// -5
#[test]
    fn test(){
        println!("{:#?}", approximate_multifactorial_digits(10.into(), -1));
    }
```
Thank you for taking the time to look at this PR.