### PR TITLE
Fix parsing of factorial of expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Previously expressions such as `(x-2)!` and `(5-1)!` were wrongly parsed and treated as calculations. This fixes it, by treating the parenthesis as "poisoned" if an alphabetical character, a second number, an empty (no num) paren or a poisoned paren is contained.

Resolves #208 