### PR TITLE
Fix termial of decimal response as subfactorial 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/calculation_tasks.rs
+++ b/src/calculation_tasks.rs
@@ -185,39 +185,43 @@ impl CalculationJob {
     ) -> Option<Calculation> {
         let calc_num = match &num {
             Number::Float(num) => match level {
+                ..0 => {
+                    let res: Float = math::fractional_termial(num.as_float().clone())
+                        * if negative % 2 != 0 { -1 } else { 1 };
+                    if res.is_finite() {
+                        return Some(Calculation {
+                            value: Number::Float(num.clone()),
+                            steps: vec![(level, negative)],
+                            result: CalculationResult::Float(res.into()),
+                        });
+                    } else {
+                        num.as_float().to_integer()?
+                    }
+                }
+                0 => {
+                    // We don't support subfactorials of deciamals
+                    return None;
+                }
                 1 => {
                     let res: Float = math::fractional_factorial(num.as_float().clone())
                         * if negative % 2 != 0 { -1 } else { 1 };
                     if res.is_finite() {
                         return Some(Calculation {
                             value: Number::Float(num.clone()),
-                            steps: vec![(1, negative)],
+                            steps: vec![(level, negative)],
                             result: CalculationResult::Float(res.into()),
                         });
                     } else {
                         num.as_float().to_integer()?
                     }
                 }
-                ..=-1 => {
-                    let res: Float = math::fractional_termial(num.as_float().clone())
+                2.. => {
+                    let res: Float = math::fractional_multifactorial(num.as_float().clone(), level)
                         * if negative % 2 != 0 { -1 } else { 1 };
                     if res.is_finite() {
                         return Some(Calculation {
                             value: Number::Float(num.clone()),
-                            steps: vec![(0, negative)],
-                            result: CalculationResult::Float(res.into()),
-                        });
-                    } else {
-                        num.as_float().to_integer()?
-                    }
-                }
-                k => {
-                    let res: Float = math::fractional_multifactorial(num.as_float().clone(), k)
-                        * if negative % 2 != 0 { -1 } else { 1 };
-                    if res.is_finite() {
-                        return Some(Calculation {
-                            value: Number::Float(num.clone()),
-                            steps: vec![(k, negative)],
+                            steps: vec![(level, negative)],
                             result: CalculationResult::Float(res.into()),
                         });
                     } else {

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -1935,6 +1935,25 @@ mod tests {
     }
 
     #[test]
+    fn test_subfactorial_confusion() {
+        let comment = RedditComment::new(
+            "What is the factorial of 287,491?",
+            "1234",
+            "test_author",
+            "test_subreddit",
+            Commands::TERMIAL,
+        )
+        .extract()
+        .calc();
+
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "The termial of 287.491 is approximately 41469.2830405 \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
     fn test_get_reply_approximate_digits_from_mixed_types() {
         let comment = RedditComment {
             id: "1234".to_string(),


### PR DESCRIPTION
This removes the magic numbers in handling of floats, where one was forgotten to be changed. Also adds explicit subfactorial case there.

Resolves #210 