### PR TITLE
Huge number input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "3.1.1"
+version = "3.2.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -275,8 +275,15 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
                 }
             }
             if !had_op {
-                if let Some(CalculationBase::Calc(job)) = &mut base {
-                    job.negative = step.0
+                match &mut base {
+                    Some(CalculationBase::Calc(job)) => job.negative += step.0,
+                    Some(CalculationBase::Num(n)) => {
+                        if step.0 % 2 != 0 {
+                            n.negate();
+                        } else {
+                        }
+                    }
+                    None => {}
                 }
             } else {
                 match &mut base {
@@ -748,11 +755,15 @@ mod test {
     }
     #[test]
     fn test_paren_negation() {
-        let jobs = parse("a factorial -(--(-15))!", true);
+        let jobs = parse("a factorial -(--(-(-(-3))!))!", true);
         assert_eq!(
             jobs,
             [CalculationJob {
-                base: CalculationBase::Num((-15).into()),
+                base: CalculationBase::Calc(Box::new(CalculationJob {
+                    base: CalculationBase::Num(3.into()),
+                    level: 1,
+                    negative: 3
+                })),
                 level: 1,
                 negative: 1
             }]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -522,7 +522,7 @@ fn parse_num(text: &mut &str) -> Option<Number> {
             .parse::<Integer>()
             .ok()?;
         let num = n * Integer::u64_pow_u64(10, exponent).complete();
-        Some(Number::Int(num))
+        Some(Number::Exact(num))
     } else {
         let x = Float::parse(format!(
             "{integer_part}.{decimal_part}{}{}{}",
@@ -534,7 +534,7 @@ fn parse_num(text: &mut &str) -> Option<Number> {
         let x = Float::with_val(FLOAT_PRECISION, x);
         if x.is_integer() && exponent + integer_part.len() as i64 <= INTEGER_CONSTRUCTION_LIMIT {
             let n = x.to_integer().unwrap();
-            Some(Number::Int(n))
+            Some(Number::Exact(n))
         } else if x.is_finite() {
             Some(Number::Float(x.into()))
         } else {
@@ -886,13 +886,13 @@ mod test {
             Some(Number::Float(Float::with_val(FLOAT_PRECISION, 0.5).into()))
         );
         let num = parse_num(&mut "1more !");
-        assert_eq!(num, Some(Number::Int(1.into())));
+        assert_eq!(num, Some(1.into()));
         let num = parse_num(&mut "1.0more !");
-        assert_eq!(num, Some(Number::Int(1.into())));
+        assert_eq!(num, Some(1.into()));
         let num = parse_num(&mut "1.5e2more !");
-        assert_eq!(num, Some(Number::Int(150.into())));
+        assert_eq!(num, Some(150.into()));
         let num = parse_num(&mut "1e2more !");
-        assert_eq!(num, Some(Number::Int(100.into())));
+        assert_eq!(num, Some(100.into()));
         let num = parse_num(&mut "1.531e2more !");
         let Some(Number::Float(f)) = num else {
             panic!("Not a float")
@@ -910,7 +910,7 @@ mod test {
     #[test]
     fn test_biggest_num() {
         let num = parse_num(&mut format!("9e{}", INTEGER_CONSTRUCTION_LIMIT).as_str());
-        assert!(!matches!(num, Some(Number::Int(_))));
+        assert!(!matches!(num, Some(Number::Exact(_))));
         let num = parse_num(&mut format!("9e{}", INTEGER_CONSTRUCTION_LIMIT - 1).as_str());
         assert!(num.is_some());
     }

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -1088,7 +1088,7 @@ mod tests {
         assert_eq!(
             comments[0].calculation_list,
             [Calculation {
-                value: Number::Int(1.into()),
+                value: Number::Exact(1.into()),
                 steps: vec![(2, 0)],
                 result: crate::calculation_results::CalculationResult::Exact(1.into())
             }]
@@ -1096,7 +1096,7 @@ mod tests {
         assert_eq!(
             comments[1].calculation_list,
             [Calculation {
-                value: Number::Int(2.into()),
+                value: Number::Exact(2.into()),
                 steps: vec![(1, 0)],
                 result: crate::calculation_results::CalculationResult::Exact(2.into())
             }]
@@ -1104,7 +1104,7 @@ mod tests {
         assert_eq!(
             comments[2].calculation_list,
             [Calculation {
-                value: Number::Int(10.into()),
+                value: Number::Exact(10.into()),
                 steps: vec![(0, 0)],
                 result: crate::calculation_results::CalculationResult::Exact(1334961.into())
             }]

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -502,18 +502,18 @@ mod tests {
             jobs,
             [
                 CalculationJob {
-                    base: CalculationBase::Num(Number::Int(24.into())),
+                    base: CalculationBase::Num(Number::Exact(24.into())),
                     level: 1,
                     negative: 0
                 },
                 CalculationJob {
-                    base: CalculationBase::Num(Number::Int(24.into())),
+                    base: CalculationBase::Num(Number::Exact(24.into())),
                     level: 1,
                     negative: 1
                 },
                 CalculationJob {
                     base: CalculationBase::Calc(Box::new(CalculationJob {
-                        base: CalculationBase::Num(Number::Int(2.into())),
+                        base: CalculationBase::Num(Number::Exact(2.into())),
                         level: 1,
                         negative: 0
                     })),
@@ -523,7 +523,7 @@ mod tests {
                 CalculationJob {
                     base: CalculationBase::Calc(Box::new(CalculationJob {
                         base: CalculationBase::Calc(Box::new(CalculationJob {
-                            base: CalculationBase::Num(Number::Int(2.into())),
+                            base: CalculationBase::Num(Number::Exact(2.into())),
                             level: 1,
                             negative: 0
                         })),
@@ -720,22 +720,22 @@ mod tests {
             comment.calculation_list,
             vec![
                 Calculation {
-                    value: Number::Int(5.into()),
+                    value: Number::Exact(5.into()),
                     steps: vec![(-1, 1)],
                     result: CalculationResult::Exact((-15).into())
                 },
                 Calculation {
-                    value: Number::Int(5.into()),
+                    value: Number::Exact(5.into()),
                     steps: vec![(0, 1)],
                     result: CalculationResult::Exact((-44).into())
                 },
                 Calculation {
-                    value: Number::Int(5.into()),
+                    value: Number::Exact(5.into()),
                     steps: vec![(1, 1)],
                     result: CalculationResult::Exact((-120).into())
                 },
                 Calculation {
-                    value: Number::Int(10.into()),
+                    value: Number::Exact(10.into()),
                     steps: vec![(1, 2)],
                     result: CalculationResult::Exact(3628800.into())
                 }
@@ -855,7 +855,7 @@ mod tests {
         assert_eq!(
             comment.calculation_list,
             vec![Calculation {
-                value: Number::Int(0.into()),
+                value: Number::Exact(0.into()),
                 steps: vec![(1, 0)],
                 result: CalculationResult::Exact(1.into())
             }]
@@ -1019,14 +1019,14 @@ mod tests {
             comment.calculation_list,
             [
                 Calculation {
+                    value: Number::Exact(10.into()),
+                    steps: vec![(1, 1)],
+                    result: CalculationResult::Exact((-3628800).into())
+                },
+                Calculation {
                     value: Number::Float(Float::with_val(FLOAT_PRECISION, Float::parse("112.342").unwrap()).into()),
                     steps: vec![(1, 0)],
                     result: CalculationResult::Float(Float::with_val(FLOAT_PRECISION, Float::parse("993525073229285436539807503113271988267318728609930136156505804196109258655775654879896155361191576205057992198378530500089998766548809286881281158234109518671597164775130317741632313.7252607309857759503328865475739439663463350416381893570704080831760770928994102217701454569735908025174055229200345933253782907").unwrap()).into())
-                },
-                Calculation {
-                    value: Number::Int(10.into()),
-                    steps: vec![(1, 1)],
-                    result: CalculationResult::Exact((-3628800).into())
                 },
             ]
         );
@@ -1909,7 +1909,7 @@ mod tests {
         let reply = comment.get_reply();
         assert_eq!(
             reply,
-            "That is so large, I can't even fit it in a comment with a power of 10 tower, so I'll have to use tetration!\n\nAll that of 1 × 10^2652 has on the order of ^(9041)10 digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+            "That is so large, I can't even fit it in a comment with a power of 10 tower, so I'll have to use tetration!\n\nAll that of roughly 1 × 10^2652 has on the order of ^(9041)10 digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
         );
     }
 
@@ -1930,7 +1930,7 @@ mod tests {
         let reply = comment.get_reply();
         assert_eq!(
             reply,
-            "That is so large, I can't even fit it in a comment with a power of 10 tower, so I'll have to use tetration!\n\nAll that of 9 × 10^99 has on the order of ^(20000)10 digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+            "That is so large, I can't even fit it in a comment with a power of 10 tower, so I'll have to use tetration!\n\nAll that of roughly 9 × 10^99 has on the order of ^(20000)10 digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
         );
     }
 
@@ -1980,6 +1980,7 @@ mod tests {
                     value: 283462.into(),
                     steps: vec![(2, 0)],
                     result: CalculationResult::ApproximateDigits(
+                        false,
                         math::approximate_multifactorial_digits(283462.into(), 2),
                     ),
                 },


### PR DESCRIPTION
This allows huge numbers as inputs like `9e9999999999999999999999`, by removing `Number` and replacing uses with `CalculationResult` via a `Number` type alias and putting such numbers into an `Approximate`.

A minor bug regarding behavior of negated parens (`(-(-3))!`) was also fixed.

Resolves #199 