### PR TITLE
Fix huge inputs limited to i64 exponent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/reddit_comment.rs
+++ b/src/reddit_comment.rs
@@ -1954,6 +1954,25 @@ mod tests {
     }
 
     #[test]
+    fn test_ridiculous_input() {
+        let comment = RedditComment::new(
+            "9e999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999!",
+            "1234",
+            "test-author",
+            "test-subreddit",
+            Commands::NONE,
+        )
+        .extract()
+        .calc();
+
+        let reply = comment.get_reply();
+        assert_eq!(
+            reply,
+            "That is so large, that I can't even give the number of digits of it, so I have to make a power of ten tower.\n\nThe factorial of 9 × 10^999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999 has on the order of 10^(1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000164) digits \n\n\n*^(This action was performed by a bot. Please DM me if you have any questions.)*"
+        );
+    }
+
+    #[test]
     fn test_get_reply_approximate_digits_from_mixed_types() {
         let comment = RedditComment {
             id: "1234".to_string(),


### PR DESCRIPTION
In #213 I forgot to change the parsed type of the exponent, limiting it, now it is `Integer`. I also fixed some clippy lints.