### PR TITLE
Fix api login by moving to new endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "arbtest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot"
-version = "3.2.2"
+version = "3.2.3"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/reddit_api.rs
+++ b/src/reddit_api.rs
@@ -37,7 +37,7 @@ const REDDIT_OAUTH_URL: &str = "https://oauth.reddit.com";
 #[cfg(test)]
 const REDDIT_OAUTH_URL: &str = "http://127.0.0.1:9384";
 #[cfg(not(test))]
-const REDDIT_TOKEN_URL: &str = "https://ssl.reddit.com/api/v1/access_token";
+const REDDIT_TOKEN_URL: &str = "https://www.reddit.com/api/v1/access_token";
 #[cfg(test)]
 const REDDIT_TOKEN_URL: &str = "http://127.0.0.1:9384";
 #[cfg(not(test))]


### PR DESCRIPTION
**Urgent!!!**

The bot is currently broken, as reddit moved the auth endpoint from https://ssl.reddit.com/api/v1/access_token to https://www.reddit.com/api/v1/access_token

This just changes that const.

@tolik518 **Pull and deploy as soon as possible!**