### PR TITLE
Add Nix devshell and package (flake)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /.env
+/.direnv
 /.idea/
 cargo-test-*
 comment_ids

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This little fella is currently running on <b>r/mathmemes</b>, <b>r/unexpectedfac
   - [Reddit API Credentials](#reddit-api-credentials)
   - [Installation](#installation)
   - [Configuration](#configuration)
-- [Usage](#usage)
+  - [Usage](#usage)
 - [Contributing](#contributing)
 
 # Getting Started
@@ -55,16 +55,36 @@ Follow these steps to set up and run the Factorion bot on your local machine and
    - A `username` and `password` (for the Reddit account that created the app)
 
 
-### Installation
-
+## Installation
+You might need to install some build dependecies: openssl, gmp, m4, pkg-config
+### With Cargo (crates.io)
+```bash
+cargo install --locked factorion-bot-reddit
+```
+### With Nix
+Use the provided flake.
+```bash
+nix build github:tolik518/factorion-bot
+# The binaries will be in result/bin
+```
+### With docker
+Skip to [Running on a server](#running-on-a-server).
+### Manually
 Fork/Clone the repository and navigate to the project directory:
 
 ```bash
-git clone https://github.com/yourusername/factorion-bot.git
+git clone https://github.com/tolik518/factorion-bot.git
 cd factorion-bot
+
+# To just build
+cargo build -r
+# The binaries will be in target/release
+
+# To install
+cargo install --path .
 ```
 
-### Configuration
+## Configuration
 
 Create a `.env` file in the project root with the following variables:
 
@@ -108,20 +128,20 @@ Setting them to `0` will result in a crash.
 
 Set `RUST_LOG` to `factorion_bot` to see all logs, or `error` to see only errors.
 
-## Run the following command to install dependencies:
-
-##### Refer to `Cargo.toml`
-
-```bash
-cargo build
-```
-
 ## Usage
 
-Run the bot with:
+If built manually, run the bot with:
 
 ```bash
 cargo run
+```
+
+Otherwise run the binary `factorion-bot-reddit`.
+```bash
+# If in path (cargo install)
+factorion-bot-reddit
+# If local nix build
+result/bin/factorion-bot-reddit
 ```
 ### How does it work in Reddit?
 1. Create a new user for the bot so it can be mentioned by `/u/<botname>`
@@ -141,8 +161,11 @@ docker compose up -d
 ```
 
 
-## Contributing
+# Contributing
 
 Feel free to submit issues or pull requests if you would like to contribute to this project.
 Help with ideas, math, code, documentation, etc. is greatly appreciated.
 If you are unsure about how to start, visit [Contributing](CONTRIBUTING.md)
+
+## Nix Devshell
+If you use nix you can use `nix develop` and/or nix-direnv to enter a devshell, that provides all dependencies.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ pkgs, pkg-config, openssl, m4, gmp }:
+
+with pkgs.lib;
+
+pkgs.rustPlatform.buildRustPackage {
+  pname = "factorion-bot-reddit";
+  version = "dev";
+  cargoLock.lockFile = ./Cargo.lock;
+  src = cleanSource ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+    m4
+  ];
+  buildInputs = [
+    openssl
+    gmp
+  ];
+
+  meta = {
+    description = "The reddit factorion-bot";
+    homepage = "https://github.com/tolik518/factorion-bot";
+    license = licenses.mit;
+  };
+}
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753939845,
+        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  description = "Development and package flake for factorion";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      # The set of systems to provide outputs for
+      allSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      # A function that provides a system-specific Nixpkgs for the desired systems
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs allSystems (
+          system:
+          f {
+            pkgs = import nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            };
+            system = system;
+          }
+        );
+    in
+    {
+      devShells = forAllSystems (
+        { pkgs, ... }:
+        with pkgs;
+        mkShell {
+          packages = [
+            # Rust
+            cargo
+            clippy
+            rust-analyzer
+            rustc
+            rustfmt
+            cargo-watch
+
+            # Project Build-Dependencies
+            pkg-config
+            openssl
+            m4
+            gmp
+            mpc
+            mpfr
+          ];
+        }
+      );
+
+      packages = forAllSystems (
+        { pkgs, ... }:
+        rec {
+          factorion-bot-reddit = pkgs.callPackage ./default.nix { };
+          default = factorion-bot-reddit;
+        }
+      );
+
+      apps = forAllSystems (
+        {system, ...}: {
+          bot-reddit = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/factorion-bot-reddit";
+            meta.description = "factorion-bot server for reddit";
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Mostly for my convenience, I added a nix flake for a devshell (provides openssl, gmp, etc.) and a package.

This also provides another way of installing easily, so I added that documentation and improved the rest a bit (moved the build guide under `Installation` to `Manually`, changed some heading levels).

This also lists an installation option through crates.io, which does not have the binary published yet. That would be added with #231.