### PR TITLE
Fix falsly calculating multitermials of decimals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "4.0.2"
+version = "4.0.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "arbtest",
  "factorion-math",

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "4.0.2"
+version = "4.0.3"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"

--- a/factorion-lib/src/calculation_tasks.rs
+++ b/factorion-lib/src/calculation_tasks.rs
@@ -234,7 +234,11 @@ impl CalculationJob {
             }
             CalculationResult::ComplexInfinity => return Some(CalculationResult::ComplexInfinity),
             Number::Float(num) => match level {
-                ..0 => {
+                ..-1 => {
+                    // We don't support multitermials of decimals
+                    return None;
+                }
+                -1 => {
                     let res: Float = math::fractional_termial(num.as_float().clone())
                         * if negative % 2 != 0 { -1 } else { 1 };
                     if res.is_finite() {
@@ -402,7 +406,37 @@ impl CalculationJob {
                 },
             )
         } else {
-            None
+            unreachable!()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use factorion_math::recommended::FLOAT_PRECISION;
+
+    #[test]
+    fn test_unsupported_calcs() {
+        // Subfactorial
+        let job = CalculationJob {
+            base: CalculationBase::Num(Number::Float(Float::with_val(FLOAT_PRECISION, 1.5).into())),
+            level: 0,
+            negative: 0,
+        };
+        assert_eq!(job.execute(false), vec![None]);
+        // Multitermial
+        let job = CalculationJob {
+            base: CalculationBase::Num(Number::Float(Float::with_val(FLOAT_PRECISION, 1.5).into())),
+            level: -2,
+            negative: 0,
+        };
+        assert_eq!(job.execute(false), vec![None]);
+        let job = CalculationJob {
+            base: CalculationBase::Num(Number::Float(Float::with_val(FLOAT_PRECISION, 1.5).into())),
+            level: -51,
+            negative: 0,
+        };
+        assert_eq!(job.execute(false), vec![None]);
     }
 }

--- a/factorion-lib/tests/integration.rs
+++ b/factorion-lib/tests/integration.rs
@@ -394,6 +394,20 @@ fn test_comment_new_decimals_termial() {
     assert_eq!(comment.status, Status::FACTORIALS_FOUND);
 }
 #[test]
+fn test_comment_new_multitermial_decimals() {
+    let _ = factorion_lib::init_default();
+    let comment = Comment::new(
+        "This is a test comment with decimal number 1294.5??",
+        (),
+        Commands::NONE,
+        MAX_LENGTH,
+    )
+    .extract()
+    .calc();
+    assert_eq!(comment.calculation_list, vec![]);
+    assert_eq!(comment.status, Status::NO_FACTORIAL);
+}
+#[test]
 fn test_comment_new_subfactorial_decimals() {
     let _ = factorion_lib::init_default();
     let comment = Comment::new(


### PR DESCRIPTION
I just unexpectedly got a response from the bot claiming to have calculated the multitermial of a decimal. As I haven't figured out an analytical continuation, that was wierd. Turns out, the bot was treating all multitermials as termials.

This adds an explicit multitermial case, adds two tests for it, and marks an unreachable region of code as such (else block after checked <, =, and > cases).