### PR TITLE
Fix skipped constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-discord"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "4.0.7"
+version = "4.0.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "arbtest",
  "factorion-math",

--- a/factorion-bot-discord/Cargo.toml
+++ b/factorion-bot-discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-discord"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Discord"
 license = "MIT"

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "4.0.7"
+version = "4.0.8"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"

--- a/factorion-lib/src/parse.rs
+++ b/factorion-lib/src/parse.rs
@@ -183,6 +183,7 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
         text = text.trim_start();
         if text.len() != last_len {
             current_negative = 0;
+            had_text_before = false;
         }
         // Text (1.)
         let Some(position_of_interest) = text.find(POI_STARTS) else {
@@ -430,6 +431,11 @@ pub fn parse(mut text: &str, do_termial: bool) -> Vec<CalculationJob> {
             };
         } else {
             // Number (7.)
+            if text.starts_with('.') && !text[1..].starts_with(char::is_numeric) {
+                // Is a period
+                text = &text[1..];
+                continue;
+            }
             let Some(num) = parse_num(&mut text, had_text, false) else {
                 had_text_before = true;
                 // advance one char to avoid loop
@@ -1065,6 +1071,18 @@ mod test {
         let _ = crate::init_default();
         let jobs = parse("!espi!", true);
         assert_eq!(jobs, []);
+        let jobs = parse("some. pi!", true);
+        assert_eq!(
+            jobs,
+            [CalculationJob {
+                base: CalculationBase::Num(Number::Float(
+                    Float::with_val(FLOAT_PRECISION, factorion_math::rug::float::Constant::Pi)
+                        .into()
+                )),
+                level: 1,
+                negative: 0
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
I noticed a bug here: https://www.reddit.com/r/mathmemes/comments/1o473zj/comment/njbhvfu/

Turns out when encountering a period, we skip one extra character (to avoid loops in numbers). And we didn't reset had_text_before on whitespace.