### PR TITLE
Handle 429 (Ratelimit Error)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "4.0.8"
+version = "4.0.9"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "4.0.8"
+version = "4.0.9"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"

--- a/factorion-bot-reddit/src/main.rs
+++ b/factorion-bot-reddit/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &mut last_ids,
             )
             .await
-            .unwrap_or_default();
+            .unwrap_or((Default::default(), (60.0, 0.0)));
         let end = SystemTime::now();
 
         influxdb::log_time_consumed(influx_client, start, end, "get_comments").await?;
@@ -199,22 +199,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 };
                 sleep(Duration::from_secs(pause as u64)).await;
                 if !dont_reply {
-                    match reddit_client.reply_to_comment(comment, &reply).await {
-                        Ok(t) => {
-                            if let Some(t) = t {
-                                rate = t;
-                            } else {
-                                warn!("Missing ratelimit");
+                    'reply: loop {
+                        match reddit_client.reply_to_comment(&comment, &reply).await {
+                            Ok(t) => {
+                                if let Some(t) = t {
+                                    rate = t;
+                                } else {
+                                    warn!("Missing ratelimit");
+                                }
+                                influxdb::log_comment_reply(
+                                    influx_client,
+                                    &comment_id,
+                                    &comment_author,
+                                    &comment_subreddit,
+                                )
+                                .await?;
                             }
-                            influxdb::log_comment_reply(
-                                influx_client,
-                                &comment_id,
-                                &comment_author,
-                                &comment_subreddit,
-                            )
-                            .await?;
+                            Err(e) => match e.downcast::<reddit_api::RateLimitErr>() {
+                                Ok(_) => {
+                                    error!("Hit the ratelimit!");
+                                    sleep(Duration::from_secs(rate.0.ceil() as u64)).await;
+                                    continue 'reply;
+                                }
+                                Err(e) => error!("Failed to reply to comment: {e:?}"),
+                            },
                         }
-                        Err(e) => error!("Failed to reply to comment: {e:?}"),
+                        break 'reply;
                     }
                 }
                 continue;

--- a/factorion-bot-reddit/src/reddit_api.rs
+++ b/factorion-bot-reddit/src/reddit_api.rs
@@ -56,6 +56,14 @@ pub(crate) struct RedditClient {
     client: Client,
     token: Token,
 }
+#[derive(Debug, Clone)]
+pub(crate) struct RateLimitErr;
+impl std::fmt::Display for RateLimitErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Ratelimit hit! Got 429.")
+    }
+}
+impl std::error::Error for RateLimitErr {}
 
 impl RedditClient {
     /// Creates a new client using the env variables APP_CLIENT_ID and APP_SECRET.
@@ -282,36 +290,45 @@ impl RedditClient {
                     res.extend(posts);
                 }
                 if let Some(ids) = ids {
-                    let response = self
-                        .client
-                        .get(format!(
-                            "{}/api/info?id={}",
-                            REDDIT_OAUTH_URL,
-                            ids.iter()
-                                .map(|(id, _)| id)
-                                .fold(String::new(), |mut a, e| {
-                                    let _ = write!(a, "{e}");
-                                    a
-                                })
-                        ))
-                        .bearer_auth(&self.token.access_token)
-                        .send()
-                        .await
-                        .expect("Failed to get comment");
-                    if Self::check_response_status(&response).is_ok() {
-                        let (comments, _, t, _) = Self::extract_comments(
-                            response,
-                            already_replied_to_comments,
-                            true,
-                            SUBREDDIT_COMMANDS.get().unwrap(),
-                            &ids.into_iter().collect(),
-                        )
-                        .await
-                        .expect("Failed to extract comments");
+                    'get_summons: loop {
+                        let response = self
+                            .client
+                            .get(format!(
+                                "{}/api/info?id={}",
+                                REDDIT_OAUTH_URL,
+                                ids.iter()
+                                    .map(|(id, _)| id)
+                                    .fold(String::new(), |mut a, e| {
+                                        let _ = write!(a, "{e}");
+                                        a
+                                    })
+                            ))
+                            .bearer_auth(&self.token.access_token)
+                            .send()
+                            .await
+                            .expect("Failed to get comment");
+                        if Self::check_response_status(&response).is_ok() {
+                            let (comments, _, t, _) = Self::extract_comments(
+                                response,
+                                already_replied_to_comments,
+                                true,
+                                SUBREDDIT_COMMANDS.get().unwrap(),
+                                &ids.into_iter().collect(),
+                            )
+                            .await
+                            .expect("Failed to extract comments");
 
-                        reset_timer = Self::update_reset_timer(reset_timer, t);
+                            reset_timer = Self::update_reset_timer(reset_timer, t);
 
-                        res.extend(comments);
+                            res.extend(comments);
+                        } else if response.status().as_u16() == 429 {
+                            tokio::time::sleep(std::time::Duration::from_secs(
+                                reset_timer.0.ceil() as u64,
+                            ))
+                            .await;
+                            continue 'get_summons;
+                        }
+                        break 'get_summons;
                     }
                 }
                 if let Some(mentions) = mentions {
@@ -351,7 +368,7 @@ impl RedditClient {
     /// May panic on a malformed response is received from the api.
     pub(crate) async fn reply_to_comment(
         &mut self,
-        comment: CommentCalculated<Meta>,
+        comment: &CommentCalculated<Meta>,
         reply: &str,
     ) -> Result<Option<(f64, f64)>, Error> {
         #[cfg(not(test))]
@@ -377,6 +394,10 @@ impl RedditClient {
             .form(&params)
             .send()
             .await?;
+
+        if response.status().as_u16() == 429 {
+            Err(RateLimitErr)?
+        };
 
         let response_headers = response.headers();
         let ratelimit_remaining: Option<f64> = response_headers
@@ -889,24 +910,22 @@ mod tests {
                 expiration_time: Utc::now(),
             },
         };
+        let comment = Comment::new_already_replied(
+            Meta {
+                id: "t1_some_id".to_owned(),
+                author: "author".to_owned(),
+                subreddit: "subressit".to_owned(),
+            },
+            MAX_COMMENT_LEN,
+        )
+        .extract()
+        .calc();
         let (status, reply_status) = join!(
             dummy_server(&[(
                 "POST / HTTP/1.1\r\nauthorization: Bearer token\r\ncontent-type: application/x-www-form-urlencoded\r\naccept: */*\r\nhost: 127.0.0.1:9384\r\ncontent-length: 32\r\n\r\ntext=I+relpy&thing_id=t1_some_id",
                 "HTTP/1.1 200 OK\r\nx-ratelimit-remaining: 10\r\nx-ratelimit-reset: 200\n\n{\"success\": true}"
             )]),
-            client.reply_to_comment(
-                Comment::new_already_replied(
-                    Meta {
-                        id: "t1_some_id".to_owned(),
-                        author: "author".to_owned(),
-                        subreddit: "subressit".to_owned()
-                    },
-                    MAX_COMMENT_LEN
-                )
-                .extract()
-                .calc(),
-                "I relpy"
-            )
+            client.reply_to_comment(&comment, "I relpy")
         );
         status.unwrap();
         let reply_status = reply_status.unwrap();


### PR DESCRIPTION
Recently we have hit the ratelimit and gotten 429 errors. Currently running into the ratelimit could lead to dropped comments. This makes it retry after the limit times out. This also means, that we don't spam requests, when Reddit has problems (500 Error), instead we wait a minute.