### PR TITLE
fix default commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.0.7"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.0.7"
+version = "5.0.8"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"


### PR DESCRIPTION
When adding locales a regression was introduced, that commands wouldn't fall back to the default of the empty subreddit.

This reintroduces that behavior. To set default commands `+::command` should be used (adds config for subreddit "" with default language "en").