### PR TITLE
Fix factorion sometimes giving wrong note with bad formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-discord"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.1.1"
+version = "5.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arbtest",
  "chrono",

--- a/factorion-bot-discord/Cargo.toml
+++ b/factorion-bot-discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-discord"
-version = "2.0.7"
+version = "2.0.8"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Discord"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math", "discord"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = { path = "../factorion-lib", version = "4.0.0", features = ["serde", "influxdb"] }
+factorion-lib = { path = "../factorion-lib", version = "4.0.1", features = ["serde", "influxdb"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time"] }
 dotenvy = "^0.15.7"

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.1.1"
+version = "5.1.2"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = {path = "../factorion-lib", version = "4.0.0", features = ["serde", "influxdb"]}
+factorion-lib = {path = "../factorion-lib", version = "4.0.1", features = ["serde", "influxdb"]}
 reqwest = { version = "0.12.26", features = ["json", "native-tls"], default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = "1.0.140"

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"

--- a/factorion-lib/src/comment.rs
+++ b/factorion-lib/src/comment.rs
@@ -521,7 +521,12 @@ impl<Meta> CommentCalculated<Meta> {
                 .all(|fact| fact.is_too_long(too_big_number))
         {
             if note.is_empty() && !self.commands.no_note {
-                let _ = note.write_str(locale.notes().remove());
+                if multiple {
+                    let _ = note.write_str(locale.notes().too_big_mult());
+                } else {
+                    let _ = note.write_str(locale.notes().too_big());
+                }
+                let _ = note.write_str("\n\n");
             };
             reply = self
                 .calculation_list

--- a/factorion-lib/tests/integration.rs
+++ b/factorion-lib/tests/integration.rs
@@ -1135,6 +1135,26 @@ fn test_get_reply_too_long_from_new_comment_for_multifactorial() {
 }
 
 #[test]
+fn test_get_reply_too_long_from_3228() {
+    let consts = Consts::default();
+    let comment = Comment::new(
+        "This is a test comment with a factorial of 3228!",
+        (),
+        Commands::NONE,
+        MAX_LENGTH,
+        "en",
+    )
+    .extract(&consts)
+    .calc(&consts);
+
+    let reply = comment.get_reply(&consts);
+    assert_eq!(
+        reply,
+        "If I post the whole number, the comment would get too long. So I had to turn it into scientific notation.\n\nFactorial of 3228 is roughly 1.225751447169156617072490231646 × 10^9927 \n\n\n*^(This action was performed by a bot.)*"
+    );
+}
+
+#[test]
 fn test_get_reply_too_long_from_number_3250() {
     let consts = Consts::default();
     let comment = Comment::new(


### PR DESCRIPTION
I noticed that in edgecases like [here](https://www.reddit.com/r/unexpectedfactorial/s/XsKAzm2YLm) factorion uses the wrong note. 

That happens when it doesn't automatically shorten and has to shorten all, the wrong message was used and no paragraph spacing was added. l likely introduced the bug with locales.

Fixed and added test case.