### PR TITLE
fix false ratelimit hit logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.2.1"
+version = "5.2.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.2.1"
+version = "5.2.2"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"

--- a/factorion-bot-reddit/src/main.rs
+++ b/factorion-bot-reddit/src/main.rs
@@ -235,7 +235,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &mut last_ids,
             )
             .await
-            .unwrap_or((Default::default(), (60.0, 0.0)));
+            .unwrap_or((Default::default(), (60.0, -1.0)));
         let end = SystemTime::now();
 
         factorion_lib::influxdb::reddit::log_time_consumed(
@@ -450,10 +450,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
 
         let sleep_between_requests = if rate.1 < requests_per_loop + 1.0 {
-            warn!(
-                "Rate limit hit! time remaining: {}, count remaining: {}",
-                rate.0, rate.1
-            );
+            if rate.1 >= 0.0 {
+                warn!(
+                    "Rate limit hit! time remaining: {}, count remaining: {}",
+                    rate.0, rate.1
+                );
+            }
             rate.0 + 1.0
         } else {
             (rate.0 / rate.1 * requests_per_loop).max(2.0) + 1.0


### PR DESCRIPTION
Recently the ratelimit seemed to be hit quite often. I thought it was weird, that they were all exactly the same. 
They are not actual ratelimit hits, but instead the bot intentionally getting into a 1 minute timeout at a `get_comments` failure (as we want to wait for the servers to recover and not spam them).

Quickest fix is just setting the count negative and silencing the log for that.

Resolves #289 