### PR TITLE
Fix typo "octingen " -> "octingen"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-discord"
-version = "2.1.5"
+version = "2.1.6"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.2.5"
+version = "5.2.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "4.1.5"
+version = "4.1.6"
 dependencies = [
  "arbtest",
  "chrono",

--- a/factorion-bot-discord/Cargo.toml
+++ b/factorion-bot-discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-discord"
-version = "2.1.5"
+version = "2.1.6"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Discord"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math", "discord"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = { path = "../factorion-lib", version = "4.1.5", features = ["serde", "influxdb"] }
+factorion-lib = { path = "../factorion-lib", version = "4.1.6", features = ["serde", "influxdb"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time"] }
 dotenvy = "^0.15.7"

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.2.5"
+version = "5.2.6"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = {path = "../factorion-lib", version = "4.1.4", features = ["serde", "influxdb"]}
+factorion-lib = {path = "../factorion-lib", version = "4.1.6", features = ["serde", "influxdb"]}
 reqwest = { version = "0.12.26", features = ["json", "native-tls"], default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = "1.0.140"

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "4.1.5"
+version = "4.1.6"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"

--- a/factorion-lib/src/calculation_results.rs
+++ b/factorion-lib/src/calculation_results.rs
@@ -416,7 +416,7 @@ impl Calculation {
             "quingen",
             "sescen",
             "septingen",
-            "octingen ",
+            "octingen",
             "nongen",
         ];
         // Note that other than milluple, these are not found in a list, but continue the pattern from mill with different starts


### PR DESCRIPTION
Exactly what the title says, I noticed in some comments, that there was a random space in tuple names after `octingen` and removed it.