### PR TITLE
Add terms of service and privacy policy for discord bot

### DIFF
--- a/factorion-bot-discord/PRIVACY.md
+++ b/factorion-bot-discord/PRIVACY.md
@@ -1,0 +1,41 @@
+# Privacy Policy
+## Working Data
+To be able to find and answer to factorials, the bot reads all messages in the channels it is active in.
+
+The message content is not stored if the server is configured correctly.
+This is due to the discord client framework, we use, which logs all Events.
+The official bot `factorion-bot` with the id `1425936019559153847`, is configured to supress these logs.
+
+## Stored Data
+Channel configuration, which inludes pre-set commands and locale, is saved.
+Additionally for development, debugging and statistical purposes, some information is logged and permanently saved.
+
+This information is saved, when factorion finds operations (factorials or similar):
+  - comment author name
+  - message and channel id
+  - the calculations which include:
+    - the parsed numbers and operations
+    - the calculated result
+  - some status information which includes:
+    - whether factorion replied
+    - whether some operation could not be calculated
+  - which commands were applied (set by user or configured for channel)
+  - which locale was used
+
+This information may be saved on errors:
+  - message and channel id
+  - information from comment excluding comment text.
+
+This information may be saved for any comment:
+  - time the message was recieved
+  - time taken to parse, calculate and format individually
+
+## Shared Data
+Some statistics may be shared with the public.
+
+Such statistics may include:
+  - time taken for parsing, calculation and formatting
+  - channel ids with number and time of factorials
+  - author names with number of factorials
+  - calculation statistics wich may include (anonymously) all information regarding individual calculations as defined above
+  - (anonymous) command statistics

--- a/factorion-bot-discord/PRIVACY.md
+++ b/factorion-bot-discord/PRIVACY.md
@@ -41,7 +41,7 @@ Such statistics may include:
 No data is ever sold.
 
 ## Deletion
-If you wish for your username (and associated statistics) to be redacted, contact us via 
+If you wish for your username (and associated statistics) to be redacted, contact us via factorion@returnnull.de
 
-## Requesting Dta
-If you wish to have insight about the data we have associated with your username, contact us via discord at 
+## Requesting Data
+If you wish to have insight about the data we have associated with your username, contact us via factorion@returnnull.de

--- a/factorion-bot-discord/PRIVACY.md
+++ b/factorion-bot-discord/PRIVACY.md
@@ -2,9 +2,7 @@
 ## Working Data
 To be able to find and answer to factorials, the bot reads all messages in the channels it is active in.
 
-The message content is not stored if the server is configured correctly.
-This is due to the discord client framework, we use, which logs all Events.
-The official bot `factorion-bot` with the id `1425936019559153847`, is configured to supress these logs.
+The official bot `factorion-bot` with the id `1425936019559153847`, does not store message content.
 
 ## Stored Data
 Channel configuration, which inludes pre-set commands and locale, is saved.
@@ -12,7 +10,7 @@ Additionally for development, debugging and statistical purposes, some informati
 
 This information is saved, when factorion finds operations (factorials or similar):
   - comment author name
-  - message and channel id
+  - message and channel id (pseudonymous)
   - the calculations which include:
     - the parsed numbers and operations
     - the calculated result
@@ -31,11 +29,16 @@ This information may be saved for any comment:
   - time taken to parse, calculate and format individually
 
 ## Shared Data
-Some statistics may be shared with the public.
+Some (pseudonymized) statistics may be shared with the public.
 
 Such statistics may include:
-  - time taken for parsing, calculation and formatting
-  - channel ids with number and time of factorials
+  - time taken for parsing, calculation and formatting, on average and at different points in time
+  - channel ids (pseudonymous) with number and time of factorials
   - author names with number of factorials
   - calculation statistics wich may include (anonymously) all information regarding individual calculations as defined above
   - (anonymous) command statistics
+
+No data is ever sold.
+
+## Deletion
+If you wish for your username (and associated statistics) to be redacted, contact us via:

--- a/factorion-bot-discord/PRIVACY.md
+++ b/factorion-bot-discord/PRIVACY.md
@@ -41,4 +41,7 @@ Such statistics may include:
 No data is ever sold.
 
 ## Deletion
-If you wish for your username (and associated statistics) to be redacted, contact us via:
+If you wish for your username (and associated statistics) to be redacted, contact us via 
+
+## Requesting Dta
+If you wish to have insight about the data we have associated with your username, contact us via discord at 

--- a/factorion-bot-discord/TERMS.md
+++ b/factorion-bot-discord/TERMS.md
@@ -1,0 +1,30 @@
+# Terms of Service
+## Definitions
+In the following, these words will be definied as follows.
+- We refers to the operators of `factorion-bot`.
+- Admin refers to a Discord server admin using `factorion-bot` on that server.
+- User refers to a Discord user commenting in channels `factorion-bot` is installed. 
+
+## Rights and Responsibilities
+### Proper Usage
+An Admin MUST have permission of the Discord server owner to install `factorion-bot` on that server.
+
+An Admin MUST reasonably inform Users, that `factorion-bot` is active in a channel and what that entails.
+
+An Admin MAY install and configure `factorion-bot` in channels.
+
+An Admin or User MUST have permission of the Discord server owner to configure `factorion-bot`,
+in particular to change the locale, which may result in unwanted language used by `factorion-bot`.
+
+A User MUST follow the Discord server rules, in particular regarding spam, interacting with and triggering `factorion-bot`.
+
+### Privacy
+Our Privacy Policy can be found [here](PRIVACY.md).
+
+## Liability
+`factorion-bot` as a free service is provided "AS IS". Other than as stated in these terms, We make no warranties, express or implied.
+
+We are especially not liable for any damages incurred through improper use of `factorion-bot`.
+
+## Changes
+These Terms may change in the future. In such a case We will attempt to inform Admins. However it is recommended to check for updates regularly.


### PR DESCRIPTION
In preparation for when we make the discord bot public, to fulfill the requirements for verification as fast as possible (when we get close to the limit of servers).