### PR TITLE
Add monitoring (logs) for missing messages (overload)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-discord"
-version = "2.1.13"
+version = "2.1.14"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.2.13"
+version = "5.2.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "4.1.12"
+version = "4.1.13"
 dependencies = [
  "arbtest",
  "chrono",

--- a/factorion-bot-discord/Cargo.toml
+++ b/factorion-bot-discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-discord"
-version = "2.1.13"
+version = "2.1.14"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Discord"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math", "discord"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = { path = "../factorion-lib", version = "4.1.12", features = ["serde", "influxdb"] }
+factorion-lib = { path = "../factorion-lib", version = "4.1.13", features = ["serde", "influxdb"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time"] }
 dotenvy = "^0.15.7"

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.2.13"
+version = "5.2.14"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = {path = "../factorion-lib", version = "4.1.12", features = ["serde", "influxdb"]}
+factorion-lib = {path = "../factorion-lib", version = "4.1.13", features = ["serde", "influxdb"]}
 reqwest = { version = "0.12.28", features = ["json", "native-tls"], default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = "1.0.140"

--- a/factorion-bot-reddit/src/main.rs
+++ b/factorion-bot-reddit/src/main.rs
@@ -228,10 +228,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let mut thread_calcs_changed = false;
 
         let start = SystemTime::now();
-        // force checking of "old" messages ca. every 15 minutes
-        if i == 0 {
-            last_ids = Default::default();
-        }
         let (comments, mut rate) = reddit_client
             .get_comments(
                 &mut already_replied_or_rejected,

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "4.1.12"
+version = "4.1.13"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"


### PR DESCRIPTION
There have been repeatedly some comments factorion does not reply to for no discernable reason. This made me  take the possibility of missing some comments, because the feeds are too fast.

This just adds some warns and logs for that and improves rechecking behavior.