### PR TITLE
Do not issue api request for no summons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-discord"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.3.0"
+version = "5.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-lib"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "arbtest",
  "chrono",

--- a/factorion-bot-discord/Cargo.toml
+++ b/factorion-bot-discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-discord"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Discord"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math", "discord"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = { path = "../factorion-lib", version = "4.2.0", features = ["serde", "influxdb"] }
+factorion-lib = { path = "../factorion-lib", version = "4.2.1", features = ["serde", "influxdb"] }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "cache"] }
 tokio = { version = "1.48.0", features = ["macros", "rt-multi-thread", "time"] }
 dotenvy = "^0.15.7"

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.3.0"
+version = "5.3.1"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"
@@ -10,7 +10,7 @@ keywords = ["factorial", "termial", "bot", "math"]
 categories = ["mathematics", "web-programming", "parser-implementations"]
 
 [dependencies]
-factorion-lib = {path = "../factorion-lib", version = "4.2.0", features = ["serde", "influxdb"]}
+factorion-lib = {path = "../factorion-lib", version = "4.2.1", features = ["serde", "influxdb"]}
 reqwest = { version = "0.12.28", features = ["json", "native-tls"], default-features = false }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
 serde_json = "1.0.140"

--- a/factorion-bot-reddit/src/reddit_api.rs
+++ b/factorion-bot-reddit/src/reddit_api.rs
@@ -342,7 +342,9 @@ impl RedditClient {
                     }
                     res.extend(posts);
                 }
-                if let Some(ids) = ids {
+                if let Some(ids) = ids
+                    && !ids.is_empty()
+                {
                     'get_summons: loop {
                         let response = self
                             .client

--- a/factorion-lib/Cargo.toml
+++ b/factorion-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-lib"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2024"
 description = "A library used to create bots to recognize and calculate factorials and related concepts"
 license = "MIT"


### PR DESCRIPTION
#318 exposed a longer existing issue, where we issued a request to get summons, even when there are none to request.
So we literally requested `https://oauth.reddit.com/api/info?id=`. That gave erroneous warnings and needlessly used up requests.