### PR TITLE
set locale of some english subs explicitly to "en" 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "factorion-bot-reddit"
-version = "5.4.1"
+version = "5.4.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/factorion-bot-reddit/Cargo.toml
+++ b/factorion-bot-reddit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "factorion-bot-reddit"
-version = "5.4.1"
+version = "5.4.2"
 edition = "2024"
 description = "factorion-bot (for factorials and related) on Reddit"
 license = "MIT"

--- a/factorion-bot-reddit/subreddits.json
+++ b/factorion-bot-reddit/subreddits.json
@@ -85,6 +85,21 @@
   "TheWordFuck": {
     "locale": "en_fuck"
   },
+  "AskReddit": {
+    "locale": "en"
+  },
+  "youngpeopleyoutube": {
+    "locale": "en"
+  },
+  "me_irl": {
+    "locale": "en"
+  },
+  "GenAlpha": {
+    "locale": "en"
+  },
+  "hardwaregore": {
+    "locale": "en"
+  },
   
   "": {
     "commands": {


### PR DESCRIPTION
Just fixed some locales by adding them to `subreddits.json`.
Mainly just to not have it say, that it can't peak the language in english speaking subreddits (that were either misconfigured or had "en-us").